### PR TITLE
[BB-1029] Additional logging and improved Workato API error handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
       BATON_WORKATO_API_KEY: ${{ secrets.BATON_WORKATO_API_KEY }}
       BATON_CONNECTOR: ./baton-workato
       BATON_WORKATO_ENV: dev
+      BATON_DISABLE_CUSTOM_ROLES_SYNC: true
 
     steps:
       - name: Install Go

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You must be an Admin or have a role with access to API Clients.
 |--------------|----------------------|-----------------------------|------------------------------------|
 | **Projects** | Projects & Folders   | List projects               | `GET /api/projects`                |
 |              | Projects & Folders   | List folders                | `GET /api/folders`                 |
+|              |                      | List custom roles           | `GET /api/roles`                   |
 | **Admin**    | Collaborators        | Get collaborators           | `GET /api/members`                 |
 |              | Collaborators        | Get collaborator            | `GET /api/members/:id`             |
 |              | Collaborators        | Update collaborator’s roles | `PUT /api/members/:id`             |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Check out [Baton](https://github.com/conductorone/baton) to learn more the proje
 
 You must be an Admin or have a role with access to API Clients.
 
+### Required Client Role permissions
+
+| Area         | Section              | Action                      | API Endpoint                       |
+|--------------|----------------------|-----------------------------|------------------------------------|
+| **Projects** | Projects & Folders   | List projects               | `GET /api/projects`                |
+|              | Projects & Folders   | List folders                | `GET /api/folders`                 |
+| **Admin**    | Collaborators        | Get collaborators           | `GET /api/members`                 |
+|              | Collaborators        | Get collaborator            | `GET /api/members/:id`             |
+|              | Collaborators        | Update collaborator’s roles | `PUT /api/members/:id`             |
+|              | Collaborators        | Get collaborator privileges | `GET /api/members/:id/privileges`  |
+
 ### Using Workato commercial platform:
 
 Generate an API KEY:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Available Commands:
 Flags:
       --client-id string             The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)
       --client-secret string         The client secret used to authenticate with ConductorOne ($BATON_CLIENT_SECRET)
+      --disable-custom-roles-sync    Disable custom roles sync ($BATON_DISABLE_CUSTOM_ROLES_SYNC)
   -f, --file string                  The path to the c1z file to sync with ($BATON_FILE) (default "sync.c1z")
   -h, --help                         help for baton-workato
       --log-format string            The output format for logs: json, console ($BATON_LOG_FORMAT) (default "json")

--- a/cmd/baton-workato/conf/config.go
+++ b/cmd/baton-workato/conf/config.go
@@ -29,6 +29,12 @@ var (
 		field.WithDefaultValue("dev"),
 	)
 
+	DisableCustomRolesSync = field.BoolField(
+		"disable-custom-roles-sync",
+		field.WithDescription("Disable custom roles sync"),
+		field.WithDefaultValue(false),
+	)
+
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or
 	// required.
@@ -36,6 +42,7 @@ var (
 		ApiKeyField,
 		WorkatoDataCenterFiekd,
 		WorkatoEnv,
+		DisableCustomRolesSync,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/cmd/baton-workato/main.go
+++ b/cmd/baton-workato/main.go
@@ -62,12 +62,14 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		return nil, err
 	}
 
+	disableCustomRolesSync := v.GetBool(conf.DisableCustomRolesSync.FieldName)
+
 	workatoClient, err := client.NewWorkatoClient(ctx, key, dataCenterUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, workatoClient, env)
+	cb, err := connector.New(ctx, workatoClient, env, disableCustomRolesSync)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/connector/client/colaborator.go
+++ b/pkg/connector/client/colaborator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -21,8 +23,8 @@ func (c *WorkatoClient) GetCollaborators(ctx context.Context) ([]Collaborator, e
 }
 
 func (c *WorkatoClient) GetCollaboratorPrivileges(ctx context.Context, id int) ([]*CollaboratorPrivilege, error) {
+	l := ctxzap.Extract(ctx)
 	var response CommonPagination[*CollaboratorPrivilege]
-
 	pathString := fmt.Sprintf(GetCollaboratorByIdPath, id)
 
 	err := c.doRequest(ctx, http.MethodGet, c.getPath(pathString), &response, nil)
@@ -31,6 +33,7 @@ func (c *WorkatoClient) GetCollaboratorPrivileges(ctx context.Context, id int) (
 	}
 
 	if len(response.Data) != 1 {
+		l.Warn("expected 1 collaborator, got %d. API client may have insufficient permissions", zap.Int("count", len(response.Data)))
 		return nil, status.Errorf(codes.NotFound, "baton-workato: expected 1 collaborator, got %d", len(response.Data))
 	}
 

--- a/pkg/connector/client/helpers.go
+++ b/pkg/connector/client/helpers.go
@@ -80,7 +80,9 @@ func (c *WorkatoClient) doRequest(ctx context.Context, method string, urlAddress
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+	// Handle supported API errors https://docs.workato.com/en/workato-api.html#http-response-codes
+	switch resp.StatusCode {
+	case http.StatusNotFound, http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusInternalServerError:
 		return getError(err, resp)
 	}
 

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -9,6 +9,8 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
 type collaboratorBuilder struct {
@@ -22,6 +24,9 @@ func (o *collaboratorBuilder) ResourceType(ctx context.Context) *v2.ResourceType
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (o *collaboratorBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Debug("Listing collaborators")
+
 	collaborators, err := o.client.GetCollaborators(ctx)
 	if err != nil {
 		return nil, "", nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Connector struct {
-	client *client.WorkatoClient
-	env    workato.Environment
+	client                 *client.WorkatoClient
+	env                    workato.Environment
+	disableCustomRolesSync bool
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
@@ -23,8 +24,8 @@ func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 	return []connectorbuilder.ResourceSyncer{
 		newCollaboratorBuilder(d.client),
 		newPrivilegeBuilder(d.client, d.env),
-		newRoleBuilder(d.client, d.env),
-		newFolderBuilder(d.client, d.env),
+		newRoleBuilder(d.client, d.env, d.disableCustomRolesSync),
+		newFolderBuilder(d.client, d.env, d.disableCustomRolesSync),
 		newProjectBuilder(d.client),
 	}
 }
@@ -50,9 +51,10 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, workatoClient *client.WorkatoClient, env workato.Environment) (*Connector, error) {
+func New(ctx context.Context, workatoClient *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool) (*Connector, error) {
 	return &Connector{
-		client: workatoClient,
-		env:    env,
+		client:                 workatoClient,
+		env:                    env,
+		disableCustomRolesSync: disableCustomRolesSync,
 	}, nil
 }

--- a/pkg/connector/folder.go
+++ b/pkg/connector/folder.go
@@ -49,9 +49,11 @@ func (o *folderBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 			return nil, "", nil, err
 		}
 
-		err = o.roleCache.buildCache(ctx)
-		if err != nil {
-			return nil, "", nil, err
+		if !o.disableCustomRolesSync {
+			err = o.roleCache.buildCache(ctx)
+			if err != nil {
+				return nil, "", nil, err
+			}
 		}
 	}
 
@@ -181,7 +183,7 @@ func (o *folderBuilder) Grants(ctx context.Context, resource *v2.Resource, pToke
 		}
 	}
 
-	if state.ResourceTypeID == roleResourceType.Id {
+	if state.ResourceTypeID == roleResourceType.Id && !o.disableCustomRolesSync {
 		folderId, err := strconv.Atoi(resource.Id.Resource)
 		if err != nil {
 			return nil, "", nil, err

--- a/pkg/connector/folder.go
+++ b/pkg/connector/folder.go
@@ -26,9 +26,10 @@ const (
 )
 
 type folderBuilder struct {
-	client    *client.WorkatoClient
-	cache     *collaboratorCache
-	roleCache *roleCache
+	client                 *client.WorkatoClient
+	cache                  *collaboratorCache
+	roleCache              *roleCache
+	disableCustomRolesSync bool
 }
 
 func (o *folderBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -214,11 +215,12 @@ func (o *folderBuilder) Grants(ctx context.Context, resource *v2.Resource, pToke
 	return rv, nextToken, nil, nil
 }
 
-func newFolderBuilder(client *client.WorkatoClient, env workato.Environment) *folderBuilder {
+func newFolderBuilder(client *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool) *folderBuilder {
 	return &folderBuilder{
-		client:    client,
-		cache:     newCollaboratorCache(client, env),
-		roleCache: newRoleCache(client),
+		client:                 client,
+		cache:                  newCollaboratorCache(client, env),
+		roleCache:              newRoleCache(client),
+		disableCustomRolesSync: disableCustomRolesSync,
 	}
 }
 

--- a/pkg/connector/folder.go
+++ b/pkg/connector/folder.go
@@ -39,6 +39,7 @@ func (o *folderBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (o *folderBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
+	l.Debug("Listing folders")
 
 	// Init cache
 	if pToken.Token == "" && parentResourceID == nil {

--- a/pkg/connector/privilege.go
+++ b/pkg/connector/privilege.go
@@ -34,6 +34,7 @@ func (o *privilegeBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (o *privilegeBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
+	l.Debug("Listing privileges")
 
 	if pToken == nil || pToken.Token == "" {
 		err := o.cache.buildCache(ctx)

--- a/pkg/connector/privilege.go
+++ b/pkg/connector/privilege.go
@@ -63,7 +63,7 @@ func (o *privilegeBuilder) List(ctx context.Context, parentResourceID *v2.Resour
 func (o *privilegeBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
 	var rv []*v2.Entitlement
 	assigmentOptions := []entitlement.EntitlementOption{
-		entitlement.WithGrantableTo(collaboratorResourceType, roleResourceType),
+		entitlement.WithGrantableTo(collaboratorResourceType),
 		entitlement.WithDescription(fmt.Sprintf("Assigned %s to scopes", collaboratorResourceType.DisplayName)),
 		entitlement.WithDisplayName(fmt.Sprintf("%s have %s`", collaboratorResourceType.DisplayName, resource.DisplayName)),
 	}

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -5,6 +5,7 @@ import (
 
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-workato/pkg/connector/client"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -22,6 +23,9 @@ func (o *projectBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (o *projectBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Debug("Listing projects")
+
 	projects, nextToken, err := o.client.GetProjects(ctx, pToken.Token)
 	if err != nil {
 		return nil, "", nil, err

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -22,10 +22,11 @@ var (
 )
 
 type roleBuilder struct {
-	client    *client.WorkatoClient
-	cache     *collaboratorCache
-	roleCache *roleCache
-	env       workato.Environment
+	client                 *client.WorkatoClient
+	cache                  *collaboratorCache
+	roleCache              *roleCache
+	env                    workato.Environment
+	disableCustomRolesSync bool
 }
 
 func (o *roleBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -268,12 +269,13 @@ func (o *roleBuilder) Revoke(_ context.Context, grant *v2.Grant) (annotations.An
 	return nil, fmt.Errorf("revoke not implemented for %s", grant.Principal.Id.ResourceType)
 }
 
-func newRoleBuilder(client *client.WorkatoClient, env workato.Environment) *roleBuilder {
+func newRoleBuilder(client *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool) *roleBuilder {
 	return &roleBuilder{
-		client:    client,
-		cache:     newCollaboratorCache(client, env),
-		roleCache: newRoleCache(client),
-		env:       env,
+		client:                 client,
+		cache:                  newCollaboratorCache(client, env),
+		roleCache:              newRoleCache(client),
+		env:                    env,
+		disableCustomRolesSync: disableCustomRolesSync,
 	}
 }
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -45,9 +45,11 @@ func (o *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			return nil, "", nil, err
 		}
 
-		err = o.roleCache.buildCache(ctx)
-		if err != nil {
-			return nil, "", nil, err
+		if !o.disableCustomRolesSync {
+			err = o.roleCache.buildCache(ctx)
+			if err != nil {
+				return nil, "", nil, err
+			}
 		}
 	}
 

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -51,19 +51,25 @@ func (o *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		}
 	}
 
-	roles, nextToken, err := o.client.GetRoles(ctx, pToken.Token)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
 	rv := make([]*v2.Resource, 0)
 
-	for _, role := range roles {
-		us, err := roleResource(&role)
+	var nextToken string
+
+	if !o.disableCustomRolesSync {
+		var roles []client.Role
+		var err error
+		roles, nextToken, err = o.client.GetRoles(ctx, pToken.Token)
 		if err != nil {
 			return nil, "", nil, err
 		}
-		rv = append(rv, us)
+
+		for _, role := range roles {
+			us, err := roleResource(&role)
+			if err != nil {
+				return nil, "", nil, err
+			}
+			rv = append(rv, us)
+		}
 	}
 
 	// Add base roles
@@ -155,7 +161,7 @@ func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 
 			rv = append(rv, newGrant)
 		}
-	} else {
+	} else if !o.disableCustomRolesSync {
 		// privilege grants implementation
 		role := o.roleCache.getRoleById(resource.Id.Resource)
 		if role == nil {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -14,6 +14,7 @@ import (
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-workato/pkg/connector/client"
 	"github.com/conductorone/baton-workato/pkg/connector/workato"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
 var (
@@ -34,6 +35,9 @@ func (o *roleBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (o *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	l.Debug("Listing roles")
+
 	if pToken.Token == "" {
 		err := o.cache.buildCache(ctx)
 		if err != nil {


### PR DESCRIPTION
Handle 401, 403 and 500 errors on Workato API requests.

Added option to disable custom roles sync for Workato instances that do not have the custom roles feature available. Otherwise, the sync will fail with 401 when attempting to query the roles API.

Documented required permissions.