### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -87,7 +87,7 @@ You'll also need to specify the location of your Workato data center. Workato di
 * SG Data Center: https://app.sg.workato.com/api/
 * AU Data Center: https://app.au.workato.com/api/
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Workato connector
 
@@ -150,7 +150,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Workato connector is now pulling access data into C1.
+**Done.** Your Workato connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -276,7 +276,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Workato connector is now pulling access data into C1.
+**Done.** Your Workato connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site.

- Restore `**Done.**` closing phrase (replaces `**That's it!**`)

These corrections prevent the sync bot from reintroducing regressions on future runs.