### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -255,7 +255,7 @@ spec:
     spec:
       containers:
       - name: baton-workato
-        image: ghcr.io/conductorone/baton-workato:latest
+        image: public.ecr.aws/conductorone/baton-workato:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -280,5 +280,3 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 
 </Tab>
 </Tabs>
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._