### PR TITLE
[CXH-1494] - Add Workato collaborator account provisioning

### DIFF
--- a/.github/actions/start-test-server/action.yml
+++ b/.github/actions/start-test-server/action.yml
@@ -1,0 +1,27 @@
+name: Start test server
+description: Build baton-workato and the test server, start it in the background, and wait for health.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Build baton-workato
+      run: go build -o baton-workato ./cmd/baton-workato
+      shell: bash
+    - name: Build test server
+      run: go build -o test-server ./cmd/test-server
+      shell: bash
+    - name: Start test server
+      run: ./test-server &
+      shell: bash
+    - name: Wait for test server
+      run: |
+        for i in $(seq 1 10); do
+          curl -sf http://localhost:8765/health > /dev/null 2>&1 && exit 0
+          sleep 1
+        done
+        echo "Test server failed to start"; exit 1
+      shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,3 +64,31 @@ jobs:
         run: |
           ./baton-workato
           baton grants --entitlement="${{ vars.BATON_ENTITLEMENT_ENV_ROLE }}" --output-format=json | jq --exit-status ".grants[] | select(.principal.id.resource == \"${{ secrets.CONNECTOR_PRINCIPAL }}\")"
+
+  account-provisioning-test:
+    # Exercises sync + account provisioning (invite/create -> delete) against the
+    # in-process Workato mock in cmd/test-server, so it needs no real tenant.
+    runs-on: ubuntu-latest
+    env:
+      BATON_LOG_LEVEL: debug
+      BATON_WORKATO_API_KEY: test-token
+      BATON_WORKATO_BASE_URL: http://localhost:8765
+      BATON_WORKATO_ENV: all
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/start-test-server
+      - name: Run sync
+        run: ./baton-workato
+      - name: Account provisioning (create/delete)
+        uses: ConductorOne/github-workflows/actions/account-provisioning@v4
+        with:
+          connector: ./baton-workato
+          account-email: newhire@example.com
+          account-login: newhire@example.com
+          account-profile: '{"name":"New Hire","email":"newhire@example.com","dev_role":"Admin"}'
+          account-type: collaborator
+          search-method: email
+      - name: Stop test server
+        if: always()
+        run: pkill -f test-server || true

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -10,7 +10,9 @@
         ]
       },
       "capabilities": [
-        "CAPABILITY_SYNC"
+        "CAPABILITY_SYNC",
+        "CAPABILITY_ACCOUNT_PROVISIONING",
+        "CAPABILITY_RESOURCE_DELETE"
       ],
       "permissions": {}
     },
@@ -90,7 +92,16 @@
   ],
   "connectorCapabilities": [
     "CAPABILITY_PROVISION",
-    "CAPABILITY_SYNC"
+    "CAPABILITY_SYNC",
+    "CAPABILITY_ACCOUNT_PROVISIONING",
+    "CAPABILITY_RESOURCE_DELETE"
   ],
-  "credentialDetails": {}
+  "credentialDetails": {
+    "capabilityAccountProvisioning": {
+      "supportedCredentialOptions": [
+        "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD"
+      ],
+      "preferredCredentialOption": "CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD"
+    }
+  }
 }

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -16,10 +16,13 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -57,6 +60,13 @@ type updateRolesRequest struct {
 }
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "test-server: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	state := NewState()
 	mux := http.NewServeMux()
 
@@ -84,10 +94,14 @@ func main() {
 	// https://docs.workato.com/workato-api/folders.html#list-folders
 	mux.HandleFunc("GET /api/folders", auth(handleFolders(state)))
 
-	log.Printf("workato test-server listening on %s (bearer token %q)", listenAddr, testToken)
-	if err := http.ListenAndServe(listenAddr, mux); err != nil {
-		log.Fatalf("test-server: %v", err)
+	srv := &http.Server{
+		Addr:              listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
+
+	log.Printf("workato test-server listening on %s (bearer token %q)", listenAddr, testToken)
+	return srv.ListenAndServe()
 }
 
 // auth enforces the Bearer scheme the real API requires. A permissive validator

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -138,9 +138,10 @@ func handleInvite(s *State) http.HandlerFunc {
 			writeErr(w, http.StatusBadRequest, "email is required")
 			return
 		}
-		// The real API requires a role/group for the invite to be usable; mirror
-		// the 400 the connector's invite-shape fix was made to satisfy.
-		if len(req.EnvRoles) == 0 && len(req.UserGroupIDs) == 0 {
+		// The real API requires env_roles on every invite — a user group does NOT
+		// satisfy it (verified: a group-only invite 400s like an empty one). Mirror
+		// that so the connector's guard is exercised against accurate behavior.
+		if len(req.EnvRoles) == 0 {
 			writeErr(w, http.StatusBadRequest, "role_name or env_roles is required")
 			return
 		}

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -123,6 +123,19 @@ func auth(next http.HandlerFunc) http.HandlerFunc {
 func handleListMembers(s *State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		members := s.ListMembers()
+		// Workato's ?email= filter is a case-insensitive substring (contains)
+		// match. Mirror it so the connector's exact-match-on-top resolution is
+		// exercised against accurate API behavior rather than the full list.
+		if q := strings.TrimSpace(r.URL.Query().Get("email")); q != "" {
+			needle := strings.ToLower(q)
+			filtered := make([]Collaborator, 0, len(members))
+			for _, m := range members {
+				if strings.Contains(strings.ToLower(m.Email), needle) {
+					filtered = append(filtered, m)
+				}
+			}
+			members = filtered
+		}
 		writeJSON(w, http.StatusOK, commonPagination[Collaborator]{Data: members, Total: len(members)})
 	}
 }

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -1,0 +1,292 @@
+// Command test-server is an in-memory mock of the Workato Team API. It serves
+// the exact endpoints, JSON shapes, auth scheme and error envelope the
+// baton-workato connector calls, so CI can exercise sync and account
+// provisioning (invite -> sync -> delete) without a real Workato tenant.
+//
+// Run locally:
+//
+//	go run ./cmd/test-server/ &
+//	baton-workato --workato-api-key test-token --workato-base-url http://localhost:8765 ...
+//
+// Every handler mirrors the documented Workato API, NOT the connector. If the
+// connector and the docs disagree, the handler follows the docs so the mismatch
+// surfaces in CI instead of being hidden.
+// https://docs.workato.com/workato-api.html
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	listenAddr = ":8765"
+	// testToken is the only credential the mock accepts. Real credentials never
+	// belong in a test server.
+	testToken = "test-token"
+)
+
+// commonPagination is the Workato `{ "data": [...], "total": N }` envelope used
+// by the members and privileges endpoints.
+type commonPagination[T any] struct {
+	Data  []T `json:"data"`
+	Total int `json:"total"`
+}
+
+type inviteEnvRole struct {
+	EnvironmentType string `json:"environment_type"`
+	Name            string `json:"name"`
+}
+
+type inviteRequest struct {
+	Name         string          `json:"name"`
+	Email        string          `json:"email"`
+	UserGroupIDs []string        `json:"user_group_ids"`
+	EnvRoles     []inviteEnvRole `json:"env_roles"`
+}
+
+type addMemberRequest struct {
+	Email string `json:"email"`
+}
+
+type updateRolesRequest struct {
+	EnvRoles []inviteEnvRole `json:"env_roles"`
+}
+
+func main() {
+	state := NewState()
+	mux := http.NewServeMux()
+
+	// Unauthenticated readiness probe for the CI wait loop (not a Workato endpoint).
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	// https://docs.workato.com/workato-api/team.html#list-collaborators
+	mux.HandleFunc("GET /api/members", auth(handleListMembers(state)))
+	// https://docs.workato.com/workato-api/team.html#add-collaborator
+	mux.HandleFunc("POST /api/members", auth(handleAddMember(state)))
+	// https://docs.workato.com/workato-api/team.html#invite-a-collaborator
+	mux.HandleFunc("POST /api/member_invitations", auth(handleInvite(state)))
+	// https://docs.workato.com/workato-api/team.html#list-collaborator-privileges
+	mux.HandleFunc("GET /api/members/{id}/privileges", auth(handlePrivileges(state)))
+	// https://docs.workato.com/workato-api/team.html#update-collaborator-roles
+	mux.HandleFunc("PUT /api/members/{id}", auth(handleUpdateMember(state)))
+	// https://docs.workato.com/workato-api/team.html#remove-a-collaborator
+	mux.HandleFunc("DELETE /api/members/{id}", auth(handleDeleteMember(state)))
+	// https://docs.workato.com/workato-api/roles.html#list-roles
+	mux.HandleFunc("GET /api/roles", auth(handleRoles(state)))
+	// https://docs.workato.com/workato-api/projects.html#list-projects
+	mux.HandleFunc("GET /api/projects", auth(handleProjects(state)))
+	// https://docs.workato.com/workato-api/folders.html#list-folders
+	mux.HandleFunc("GET /api/folders", auth(handleFolders(state)))
+
+	log.Printf("workato test-server listening on %s (bearer token %q)", listenAddr, testToken)
+	if err := http.ListenAndServe(listenAddr, mux); err != nil {
+		log.Fatalf("test-server: %v", err)
+	}
+}
+
+// auth enforces the Bearer scheme the real API requires. A permissive validator
+// would hide auth-header bugs that only surface against production.
+func auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer "+testToken {
+			writeErr(w, http.StatusUnauthorized, "Unauthorized")
+			return
+		}
+		next(w, r)
+	}
+}
+
+func handleListMembers(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		members := s.ListMembers()
+		writeJSON(w, http.StatusOK, commonPagination[Collaborator]{Data: members, Total: len(members)})
+	}
+}
+
+func handleInvite(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req inviteRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		if strings.TrimSpace(req.Email) == "" {
+			writeErr(w, http.StatusBadRequest, "email is required")
+			return
+		}
+		// The real API requires a role/group for the invite to be usable; mirror
+		// the 400 the connector's invite-shape fix was made to satisfy.
+		if len(req.EnvRoles) == 0 && len(req.UserGroupIDs) == 0 {
+			writeErr(w, http.StatusBadRequest, "role_name or env_roles is required")
+			return
+		}
+
+		// Workato's real invite is async (the collaborator must accept an email
+		// before becoming a member). The test server collapses that into
+		// immediate membership so CI can exercise create -> sync -> delete; the
+		// connector's pending-invite (ActionRequired) path is covered against the
+		// live API instead.
+		roles := make([]SimpleRole, 0, len(req.EnvRoles))
+		for _, er := range req.EnvRoles {
+			roles = append(roles, SimpleRole{EnvironmentType: er.EnvironmentType, RoleName: er.Name})
+		}
+
+		if _, exists := s.CreateMember(req.Name, req.Email, roles); exists {
+			writeErr(w, http.StatusConflict, "collaborator already exists")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"result": "ok"})
+	}
+}
+
+func handleAddMember(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req addMemberRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		if strings.TrimSpace(req.Email) == "" {
+			writeErr(w, http.StatusBadRequest, "email is required")
+			return
+		}
+		if _, exists := s.CreateMember(req.Email, req.Email, nil); exists {
+			writeErr(w, http.StatusConflict, "collaborator already exists")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"result": "ok"})
+	}
+}
+
+func handlePrivileges(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, err := pathID(r); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid member id")
+			return
+		}
+		// Seeded/created members carry no per-collaborator privilege rows; the
+		// connector treats an empty list as "no privileges" and skips them.
+		writeJSON(w, http.StatusOK, commonPagination[CollaboratorPrivilege]{Data: []CollaboratorPrivilege{}, Total: 0})
+	}
+}
+
+// CollaboratorPrivilege mirrors the privileges endpoint element shape.
+// https://docs.workato.com/workato-api/team.html#list-collaborator-privileges
+type CollaboratorPrivilege struct {
+	EnvironmentType string              `json:"environment_type"`
+	Name            string              `json:"name"`
+	Privileges      map[string][]string `json:"privileges"`
+	FolderIDs       []int               `json:"folder_ids"`
+}
+
+func handleUpdateMember(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := pathID(r)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid member id")
+			return
+		}
+		var req updateRolesRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		roles := make([]SimpleRole, 0, len(req.EnvRoles))
+		for _, er := range req.EnvRoles {
+			roles = append(roles, SimpleRole{EnvironmentType: er.EnvironmentType, RoleName: er.Name})
+		}
+		if ok := s.UpdateMemberRoles(id, roles); !ok {
+			writeErr(w, http.StatusNotFound, "collaborator not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"result": "ok"})
+	}
+}
+
+func handleDeleteMember(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id, err := pathID(r)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid member id")
+			return
+		}
+		if ok := s.DeleteMember(id); !ok {
+			// Real API returns 404 for an unknown member; the connector maps that
+			// to NotFound and treats delete as idempotent success.
+			writeErr(w, http.StatusNotFound, "collaborator not found")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func handleRoles(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		roles := s.Roles()
+		writeJSON(w, http.StatusOK, paginate(r, roles))
+	}
+}
+
+func handleProjects(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projects := s.Projects()
+		writeJSON(w, http.StatusOK, paginate(r, projects))
+	}
+}
+
+func handleFolders(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		folders := s.Folders()
+		if raw := r.URL.Query().Get("parent_id"); raw != "" {
+			if parentID, err := strconv.Atoi(raw); err == nil {
+				filtered := folders[:0:0]
+				for _, f := range folders {
+					if f.ParentId == parentID {
+						filtered = append(filtered, f)
+					}
+				}
+				folders = filtered
+			}
+		}
+		writeJSON(w, http.StatusOK, paginate(r, folders))
+	}
+}
+
+// paginate mirrors the page/per_page contract of the roles/projects/folders
+// endpoints: the connector requests page 0 and stops once a page returns fewer
+// than per_page rows, so any page beyond the first is empty here.
+func paginate[T any](r *http.Request, all []T) []T {
+	page := 0
+	if raw := r.URL.Query().Get("page"); raw != "" {
+		if p, err := strconv.Atoi(raw); err == nil {
+			page = p
+		}
+	}
+	if page > 0 {
+		return []T{}
+	}
+	return all
+}
+
+func pathID(r *http.Request) (int, error) {
+	return strconv.Atoi(r.PathValue("id"))
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// writeErr emits the Workato `{ "message": "..." }` error envelope the connector
+// decodes into client.ApiError.
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"message": msg})
+}

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -42,6 +42,7 @@ type commonPagination[T any] struct {
 type inviteEnvRole struct {
 	EnvironmentType string `json:"environment_type"`
 	Name            string `json:"name"`
+	RoleType        string `json:"role_type"`
 }
 
 type inviteRequest struct {
@@ -89,6 +90,8 @@ func run() error {
 	mux.HandleFunc("DELETE /api/members/{id}", auth(handleDeleteMember(state)))
 	// https://docs.workato.com/workato-api/roles.html#list-roles
 	mux.HandleFunc("GET /api/roles", auth(handleRoles(state)))
+	// https://docs.workato.com/workato-api/environment-roles.html#list-environment-roles
+	mux.HandleFunc("GET /api/environment_roles", auth(handleEnvironmentRoles(state)))
 	// https://docs.workato.com/workato-api/projects.html#list-projects
 	mux.HandleFunc("GET /api/projects", auth(handleProjects(state)))
 	// https://docs.workato.com/workato-api/folders.html#list-folders
@@ -149,7 +152,7 @@ func handleInvite(s *State) http.HandlerFunc {
 		// live API instead.
 		roles := make([]SimpleRole, 0, len(req.EnvRoles))
 		for _, er := range req.EnvRoles {
-			roles = append(roles, SimpleRole{EnvironmentType: er.EnvironmentType, RoleName: er.Name})
+			roles = append(roles, SimpleRole{EnvironmentType: er.EnvironmentType, RoleName: er.Name, RoleType: er.RoleType})
 		}
 
 		if _, exists := s.CreateMember(req.Name, req.Email, roles); exists {
@@ -214,7 +217,7 @@ func handleUpdateMember(s *State) http.HandlerFunc {
 		}
 		roles := make([]SimpleRole, 0, len(req.EnvRoles))
 		for _, er := range req.EnvRoles {
-			roles = append(roles, SimpleRole{EnvironmentType: er.EnvironmentType, RoleName: er.Name})
+			roles = append(roles, SimpleRole{EnvironmentType: er.EnvironmentType, RoleName: er.Name, RoleType: er.RoleType})
 		}
 		if ok := s.UpdateMemberRoles(id, roles); !ok {
 			writeErr(w, http.StatusNotFound, "collaborator not found")
@@ -245,6 +248,27 @@ func handleRoles(s *State) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		roles := s.Roles()
 		writeJSON(w, http.StatusOK, paginate(r, roles))
+	}
+}
+
+// handleEnvironmentRoles serves GET /api/environment_roles. It supports the ?name=
+// exact-match filter the connector uses to resolve an invite role's type, and
+// page[number]/page[size] pagination for environment-role sync. The response is the
+// {data, total} envelope the client decodes into CommonPagination.
+func handleEnvironmentRoles(s *State) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		roles := s.EnvironmentRoles()
+		if name := r.URL.Query().Get("name"); name != "" {
+			filtered := roles[:0:0]
+			for _, role := range roles {
+				if role.Name == name {
+					filtered = append(filtered, role)
+				}
+			}
+			roles = filtered
+		}
+		roles = paginateNumbered(r, roles)
+		writeJSON(w, http.StatusOK, commonPagination[EnvironmentRole]{Data: roles, Total: len(roles)})
 	}
 }
 
@@ -284,6 +308,22 @@ func paginate[T any](r *http.Request, all []T) []T {
 		}
 	}
 	if page > 0 {
+		return []T{}
+	}
+	return all
+}
+
+// paginateNumbered mirrors the page[number]/page[size] contract of the
+// environment-roles endpoint: the connector requests page 1 and keeps paging until
+// a page comes back empty, so any page beyond the first returns no rows here.
+func paginateNumbered[T any](r *http.Request, all []T) []T {
+	page := 1
+	if raw := r.URL.Query().Get("page[number]"); raw != "" {
+		if p, err := strconv.Atoi(raw); err == nil {
+			page = p
+		}
+	}
+	if page > 1 {
 		return []T{}
 	}
 	return all

--- a/cmd/test-server/state.go
+++ b/cmd/test-server/state.go
@@ -10,11 +10,14 @@ import (
 // (see pkg/connector/client/models.go). They are intentionally duplicated here
 // so the test server has no dependency on the connector packages.
 
-// SimpleRole is a per-environment role assignment on a collaborator.
+// SimpleRole is a per-environment role assignment on a collaborator. RoleType is
+// "environment" for environment-type roles and empty (privilege_group) otherwise,
+// mirroring what the connector sends and what list-collaborators returns.
 // https://docs.workato.com/workato-api/team.html#list-collaborators
 type SimpleRole struct {
 	EnvironmentType string `json:"environment_type"`
 	RoleName        string `json:"role_name"`
+	RoleType        string `json:"role_type,omitempty"`
 }
 
 // Collaborator mirrors a Workato team member.
@@ -40,6 +43,19 @@ type Role struct {
 	CreatedAt   time.Time           `json:"created_at"`
 	UpdatedAt   time.Time           `json:"updated_at"`
 	Privileges  map[string][]string `json:"privileges"`
+}
+
+// EnvironmentRole mirrors a Workato environment role. The connector resolves an
+// invite role name against these to decide its role_type, and syncs them as the
+// environment_role resource type.
+// https://docs.workato.com/workato-api/environment-roles.html#list-environment-roles
+type EnvironmentRole struct {
+	Id           int       `json:"id"`
+	Name         string    `json:"name"`
+	Type         string    `json:"type"`
+	MembersCount int       `json:"members_count"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 // Folder mirrors a Workato folder.
@@ -70,9 +86,10 @@ type State struct {
 	memberOrder []int
 	nextID      int
 
-	roles    []Role
-	folders  []Folder
-	projects []Project
+	roles            []Role
+	environmentRoles []EnvironmentRole
+	folders          []Folder
+	projects         []Project
 }
 
 var seedTime = time.Date(2024, time.January, 2, 15, 4, 5, 0, time.UTC)
@@ -103,6 +120,13 @@ func seed(s *State) {
 	s.roles = []Role{
 		{Id: 1, Name: "Custom Reviewer", Inheritable: false, FolderIDs: []int{}, CreatedAt: seedTime, UpdatedAt: seedTime, Privileges: map[string][]string{}},
 		{Id: 2, Name: "Custom Auditor", Inheritable: true, FolderIDs: []int{}, CreatedAt: seedTime, UpdatedAt: seedTime, Privileges: map[string][]string{}},
+	}
+
+	// Environment roles let the invite path resolve a role name to role_type
+	// "environment"; names absent here (e.g. "Admin") fall back to privilege_group.
+	s.environmentRoles = []EnvironmentRole{
+		{Id: 50, Name: "Deployer", Type: "environment", MembersCount: 0, CreatedAt: seedTime, UpdatedAt: seedTime},
+		{Id: 51, Name: "Releaser", Type: "environment", MembersCount: 0, CreatedAt: seedTime, UpdatedAt: seedTime},
 	}
 
 	s.folders = []Folder{
@@ -204,6 +228,12 @@ func (s *State) Roles() []Role {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return slices.Clone(s.roles)
+}
+
+func (s *State) EnvironmentRoles() []EnvironmentRole {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.environmentRoles)
 }
 
 func (s *State) Folders() []Folder {

--- a/cmd/test-server/state.go
+++ b/cmd/test-server/state.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+// The structs below mirror the JSON shapes the baton-workato client decodes
+// (see pkg/connector/client/models.go). They are intentionally duplicated here
+// so the test server has no dependency on the connector packages.
+
+// SimpleRole is a per-environment role assignment on a collaborator.
+// https://docs.workato.com/workato-api/team.html#list-collaborators
+type SimpleRole struct {
+	EnvironmentType string `json:"environment_type"`
+	RoleName        string `json:"role_name"`
+}
+
+// Collaborator mirrors a Workato team member.
+// https://docs.workato.com/workato-api/team.html#list-collaborators
+type Collaborator struct {
+	Id         int          `json:"id"`
+	GrantType  string       `json:"grant_type"`
+	Roles      []SimpleRole `json:"roles"`
+	ExternalId string       `json:"external_id"`
+	Name       string       `json:"name"`
+	Email      string       `json:"email"`
+	TimeZone   string       `json:"time_zone"`
+	CreatedAt  time.Time    `json:"created_at"`
+}
+
+// Role mirrors a Workato custom role.
+// https://docs.workato.com/workato-api/roles.html#list-roles
+type Role struct {
+	Id          int                 `json:"id"`
+	Name        string              `json:"name"`
+	Inheritable bool                `json:"inheritable"`
+	FolderIDs   []int               `json:"folder_ids"`
+	CreatedAt   time.Time           `json:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at"`
+	Privileges  map[string][]string `json:"privileges"`
+}
+
+// Folder mirrors a Workato folder.
+// https://docs.workato.com/workato-api/folders.html#list-folders
+type Folder struct {
+	Id        int       `json:"id"`
+	Name      string    `json:"name"`
+	ParentId  int       `json:"parent_id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Project mirrors a Workato project.
+// https://docs.workato.com/workato-api/projects.html#list-projects
+type Project struct {
+	Id          int    `json:"id"`
+	Description string `json:"description"`
+	FolderId    int    `json:"folder_id"`
+	Name        string `json:"name"`
+}
+
+// State is the in-memory store. Every access goes through a method that holds
+// the mutex so parallel CI requests can't race.
+type State struct {
+	mu sync.Mutex
+
+	members     map[int]*Collaborator
+	memberOrder []int
+	nextID      int
+
+	roles    []Role
+	folders  []Folder
+	projects []Project
+}
+
+var seedTime = time.Date(2024, time.January, 2, 15, 4, 5, 0, time.UTC)
+
+// NewState returns a freshly seeded store. CI spins up a new server (and thus a
+// new seed) per job, so there is deliberately no reset endpoint.
+func NewState() *State {
+	s := &State{
+		members: make(map[int]*Collaborator),
+		nextID:  1000,
+	}
+	seed(s)
+	return s
+}
+
+func seed(s *State) {
+	// Members: base roles only (Admin/Operator) so collaborator role-grant
+	// emission resolves without depending on synced custom roles; carol has no
+	// roles to exercise the empty-grants path.
+	s.createMemberLocked("Alice Admin", "alice@example.com", []SimpleRole{
+		{EnvironmentType: "dev", RoleName: "Admin"},
+	})
+	s.createMemberLocked("Bob Operator", "bob@example.com", []SimpleRole{
+		{EnvironmentType: "prod", RoleName: "Operator"},
+	})
+	s.createMemberLocked("Carol NoRoles", "carol@example.com", nil)
+
+	s.roles = []Role{
+		{Id: 1, Name: "Custom Reviewer", Inheritable: false, FolderIDs: []int{}, CreatedAt: seedTime, UpdatedAt: seedTime, Privileges: map[string][]string{}},
+		{Id: 2, Name: "Custom Auditor", Inheritable: true, FolderIDs: []int{}, CreatedAt: seedTime, UpdatedAt: seedTime, Privileges: map[string][]string{}},
+	}
+
+	s.folders = []Folder{
+		{Id: 10, Name: "Home", ParentId: 0, CreatedAt: seedTime, UpdatedAt: seedTime},
+		{Id: 11, Name: "Shared", ParentId: 10, CreatedAt: seedTime, UpdatedAt: seedTime},
+	}
+
+	s.projects = []Project{
+		{Id: 100, Name: "Billing Pipelines", Description: "Finance integrations", FolderId: 10},
+		{Id: 101, Name: "HR Pipelines", Description: "People integrations", FolderId: 11},
+	}
+}
+
+// createMemberLocked assumes the caller already holds s.mu.
+func (s *State) createMemberLocked(name, email string, roles []SimpleRole) *Collaborator {
+	id := s.nextID
+	s.nextID++
+	m := &Collaborator{
+		Id:         id,
+		GrantType:  "user",
+		Roles:      roles,
+		ExternalId: "",
+		Name:       name,
+		Email:      email,
+		TimeZone:   "UTC",
+		CreatedAt:  seedTime,
+	}
+	s.members[id] = m
+	s.memberOrder = append(s.memberOrder, id)
+	return m
+}
+
+// ListMembers returns copies of all members in insertion order.
+func (s *State) ListMembers() []Collaborator {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Collaborator, 0, len(s.memberOrder))
+	for _, id := range s.memberOrder {
+		out = append(out, *s.members[id])
+	}
+	return out
+}
+
+// GetMemberByEmail returns the member with the given email (case-insensitive).
+func (s *State) GetMemberByEmail(email string) (Collaborator, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range s.memberOrder {
+		if equalFold(s.members[id].Email, email) {
+			return *s.members[id], true
+		}
+	}
+	return Collaborator{}, false
+}
+
+// CreateMember adds a new member and returns a copy. The bool reports whether a
+// member with that email already existed (caller maps this to HTTP 409).
+func (s *State) CreateMember(name, email string, roles []SimpleRole) (Collaborator, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range s.memberOrder {
+		if equalFold(s.members[id].Email, email) {
+			return *s.members[id], true
+		}
+	}
+	if name == "" {
+		name = email
+	}
+	m := s.createMemberLocked(name, email, roles)
+	return *m, false
+}
+
+// DeleteMember removes a member by id. Returns false when it does not exist.
+func (s *State) DeleteMember(id int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.members[id]; !ok {
+		return false
+	}
+	delete(s.members, id)
+	s.memberOrder = slices.DeleteFunc(s.memberOrder, func(x int) bool { return x == id })
+	return true
+}
+
+// UpdateMemberRoles replaces a member's roles. Returns false when it does not exist.
+func (s *State) UpdateMemberRoles(id int, roles []SimpleRole) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, ok := s.members[id]
+	if !ok {
+		return false
+	}
+	m.Roles = roles
+	return true
+}
+
+// Roles / Folders / Projects return copies of the seeded slices.
+func (s *State) Roles() []Role {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.roles)
+}
+
+func (s *State) Folders() []Folder {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.folders)
+}
+
+func (s *State) Projects() []Project {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.projects)
+}
+
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	return toLower(a) == toLower(b)
+}
+
+func toLower(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + ('a' - 'A')
+		}
+	}
+	return string(b)
+}

--- a/config_schema.json
+++ b/config_schema.json
@@ -144,12 +144,6 @@
       "displayName": "Disable custom roles sync",
       "description": "Whether to disable custom roles sync or not",
       "boolField": {}
-    },
-    {
-      "name": "workato-base-url",
-      "displayName": "Base URL override",
-      "description": "Override the API base URL. Leave empty to use the selected data center; set only for self-hosted proxies or integration tests against the local test server.",
-      "stringField": {}
     }
   ],
   "displayName": "Workato",

--- a/config_schema.json
+++ b/config_schema.json
@@ -144,6 +144,12 @@
       "displayName": "Disable custom roles sync",
       "description": "Whether to disable custom roles sync or not",
       "boolField": {}
+    },
+    {
+      "name": "workato-base-url",
+      "displayName": "Base URL override",
+      "description": "Override the API base URL. Leave empty to use the selected data center; set only for self-hosted proxies or integration tests against the local test server.",
+      "stringField": {}
     }
   ],
   "displayName": "Workato",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -10,7 +10,7 @@ sidebarTitle: Workato
 
 | Resource     | Sync | Provision |
 | :--- | :--- | :--- |
-| Accounts     | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   |           |       
+| Accounts     | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>        | 
 | Privileges   | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   |           | 
 | Roles        | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>        | 
 | Folders      | <Icon icon="square-check" iconType="solid"  color="#c937ae"/>   |           | 
@@ -39,6 +39,9 @@ Select the following endpoints:
     | **Admin**    | Collaborators        | Get collaborators           | `GET /api/members`                 |
     |              | Collaborators        | Get collaborator            | `GET /api/members/:id`             |
     |              | Collaborators        | Update collaborators’ roles* | `PUT /api/members/:id`             |
+    |              | Collaborators        | Invite collaborator         | `POST /api/member_invitations`     |
+    |              | Collaborators        | Add existing collaborator   | `POST /api/members`                |
+    |              | Collaborators        | Remove collaborator         | `DELETE /api/members/:id`          |
     |              | Collaborators        | Get collaborator privileges | `GET /api/members/:id/privileges`  |
     |              | Collaborator roles   | List non-system roles       | `GET /api/roles`                   |
     |              | Environment roles    | List environment roles†     | `GET /api/environment_roles`       |

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Workato struct {
 	WorkatoDataCenter string `mapstructure:"workato-data-center"`
 	WorkatoEnv string `mapstructure:"workato-env"`
 	DisableCustomRolesSync bool `mapstructure:"disable-custom-roles-sync"`
+	WorkatoBaseUrl string `mapstructure:"workato-base-url"`
 }
 
 func (c *Workato) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ var (
 		"workato-base-url",
 		field.WithDisplayName("Base URL override"),
 		field.WithDescription("Override the API base URL. Leave empty to use the selected data center; set only for self-hosted proxies or integration tests against the local test server."),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	WorkatoEnv = field.SelectField(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,15 @@ var (
 		field.WithDefaultValue("us"),
 	)
 
+	// BaseUrlField overrides the data-center-derived base URL. It is empty in
+	// production (the data center selection is used) and only set for integration
+	// tests that point the connector at the local cmd/test-server mock.
+	BaseUrlField = field.StringField(
+		"workato-base-url",
+		field.WithDisplayName("Base URL override"),
+		field.WithDescription("Override the API base URL. Leave empty to use the selected data center; set only for self-hosted proxies or integration tests against the local test server."),
+	)
+
 	WorkatoEnv = field.SelectField(
 		"workato-env",
 		[]string{"dev", "test", "prod", "all"},
@@ -44,6 +53,7 @@ var (
 		WorkatoDataCenterFiekd,
 		WorkatoEnv,
 		DisableCustomRolesSync,
+		BaseUrlField,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/connector/client/colaborator.go
+++ b/pkg/connector/client/colaborator.go
@@ -48,17 +48,25 @@ func (c *WorkatoClient) GetCollaboratorPrivileges(ctx context.Context, id int) (
 }
 
 // GetCollaboratorByEmail returns the collaborator matching email, or a NotFound
-// status error if no collaborator in the tenant has that email. Workato has no
-// lookup-by-email endpoint, so this scans the members list.
+// status error if no collaborator in the tenant has that email. The Workato email
+// filter is a substring (contains) match, so we apply an exact case-insensitive
+// check against the returned results.
 func (c *WorkatoClient) GetCollaboratorByEmail(ctx context.Context, email string) (*Collaborator, error) {
-	collaborators, _, err := c.GetCollaborators(ctx)
+	var response CommonPagination[Collaborator]
+
+	uri := c.getPath(collaboratorsPath)
+	query := uri.Query()
+	query.Set("email", email)
+	uri.RawQuery = query.Encode()
+
+	_, err := c.doRequest(ctx, http.MethodGet, uri, &response, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	for i := range collaborators {
-		if strings.EqualFold(collaborators[i].Email, email) {
-			return collaborators[i], nil
+	for i := range response.Data {
+		if strings.EqualFold(response.Data[i].Email, email) {
+			return &response.Data[i], nil
 		}
 	}
 

--- a/pkg/connector/client/colaborator.go
+++ b/pkg/connector/client/colaborator.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // GetCollaborators returns all team collaborators.
@@ -43,6 +45,48 @@ func (c *WorkatoClient) GetCollaboratorPrivileges(ctx context.Context, id int) (
 	}
 
 	return response.Data, annos, nil
+}
+
+// GetCollaboratorByEmail returns the collaborator matching email, or a NotFound
+// status error if no collaborator in the tenant has that email. Workato has no
+// lookup-by-email endpoint, so this scans the members list.
+func (c *WorkatoClient) GetCollaboratorByEmail(ctx context.Context, email string) (*Collaborator, error) {
+	collaborators, _, err := c.GetCollaborators(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range collaborators {
+		if strings.EqualFold(collaborators[i].Email, email) {
+			return collaborators[i], nil
+		}
+	}
+
+	return nil, status.Errorf(codes.NotFound, "baton-workato: collaborator with email %s not found", email)
+}
+
+// InviteCollaborator sends a Workato invitation email to a new collaborator via
+// POST /api/member_invitations. The collaborator becomes a full member only once
+// they accept the email invitation.
+func (c *WorkatoClient) InviteCollaborator(ctx context.Context, body InviteCollaboratorRequest) error {
+	_, err := c.doRequest(ctx, http.MethodPost, c.getPath(InviteCollaboratorPath), nil, body)
+	return err
+}
+
+// AddExistingCollaborator adds an email that already belongs to a Workato user
+// directly to the team via POST /api/members (no invitation email is sent).
+func (c *WorkatoClient) AddExistingCollaborator(ctx context.Context, email string) error {
+	body := AddCollaboratorRequest{Email: email}
+	_, err := c.doRequest(ctx, http.MethodPost, c.getPath(AddCollaboratorPath), nil, body)
+	return err
+}
+
+// DeleteCollaborator removes a collaborator via DELETE /api/members/{id}. Workato
+// has no soft-disable, so this is a hard delete. Returns a NotFound status error
+// (mapped from HTTP 404) when the collaborator is already gone.
+func (c *WorkatoClient) DeleteCollaborator(ctx context.Context, id int) error {
+	_, err := c.doRequest(ctx, http.MethodDelete, c.getPath(collaboratorsPath).JoinPath(strconv.Itoa(id)), nil, nil)
+	return err
 }
 
 // UpdateCollaboratorRoles updates the collaborator's roles for the environments

--- a/pkg/connector/client/helpers.go
+++ b/pkg/connector/client/helpers.go
@@ -12,9 +12,16 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
+	// Collaborator (member) provisioning paths.
+	// https://docs.workato.com/workato-api/team.html
+	InviteCollaboratorPath     = "api/member_invitations"
+	AddCollaboratorPath        = "api/members"
+	DeleteCollaboratorByIdPath = "api/members/%d"
+
 	AuthHeaderName = "Authorization"
 
 	// WorkatoDataCenters
@@ -69,6 +76,19 @@ func (c *WorkatoClient) doRequest(ctx context.Context, method string, urlAddress
 	defer resp.Body.Close()
 
 	return annos, nil
+}
+
+// IsNotFoundError reports whether err maps to a gRPC NotFound status. uhttp maps
+// HTTP 404 responses to codes.NotFound. Used for idempotent Delete handling.
+func IsNotFoundError(err error) bool {
+	return status.Code(err) == codes.NotFound
+}
+
+// IsAlreadyExistsError reports whether err maps to a gRPC AlreadyExists status.
+// uhttp maps HTTP 409 responses to codes.AlreadyExists. Used for idempotent
+// CreateAccount handling.
+func IsAlreadyExistsError(err error) bool {
+	return status.Code(err) == codes.AlreadyExists
 }
 
 func nextToken[T any](response []T, page int) string {

--- a/pkg/connector/client/helpers.go
+++ b/pkg/connector/client/helpers.go
@@ -18,9 +18,8 @@ import (
 var (
 	// Collaborator (member) provisioning paths.
 	// https://docs.workato.com/workato-api/team.html
-	InviteCollaboratorPath     = "api/member_invitations"
-	AddCollaboratorPath        = "api/members"
-	DeleteCollaboratorByIdPath = "api/members/%d"
+	InviteCollaboratorPath = "api/member_invitations"
+	AddCollaboratorPath    = "api/members"
 
 	AuthHeaderName = "Authorization"
 

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -73,11 +73,13 @@ func (s *SimpleRole) Equals(other SimpleRole) bool {
 
 // InviteEnvRole is a single per-environment role assignment in a member
 // invitation. Name is the role NAME (e.g. "Admin"/"Operator"/"Analyst"), not a
-// numeric id, matching the official Workato Team API.
+// numeric id, matching the official Workato Team API. RoleType is "environment"
+// for environment-type roles; when empty Workato defaults it to "privilege_group".
 // https://docs.workato.com/workato-api/team.html#invite-a-collaborator
 type InviteEnvRole struct {
 	EnvironmentType string `json:"environment_type"`
 	Name            string `json:"name"`
+	RoleType        string `json:"role_type,omitempty"`
 }
 
 // InviteCollaboratorRequest is the body for POST /api/member_invitations. It sends

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -71,6 +71,32 @@ func (s *SimpleRole) Equals(other SimpleRole) bool {
 		s.RoleName == other.RoleName
 }
 
+// InviteEnvRole is a single per-environment role assignment in a member
+// invitation. Name is the role NAME (e.g. "Admin"/"Operator"/"Analyst"), not a
+// numeric id, matching the official Workato Team API.
+// https://docs.workato.com/workato-api/team.html#invite-a-collaborator
+type InviteEnvRole struct {
+	EnvironmentType string `json:"environment_type"`
+	Name            string `json:"name"`
+}
+
+// InviteCollaboratorRequest is the body for POST /api/member_invitations. It sends
+// a Workato invitation email to a brand-new collaborator. env_roles is an array of
+// {environment_type, name} objects and user_group_ids is an array of string ids,
+// mirroring UpdateCollaboratorRoles and the official Workato Team API.
+type InviteCollaboratorRequest struct {
+	Name         string          `json:"name"`
+	Email        string          `json:"email"`
+	UserGroupIDs []string        `json:"user_group_ids,omitempty"`
+	EnvRoles     []InviteEnvRole `json:"env_roles,omitempty"`
+}
+
+// AddCollaboratorRequest is the body for POST /api/members. It adds an email that
+// already belongs to a Workato user directly to the team (no invitation email).
+type AddCollaboratorRequest struct {
+	Email string `json:"email"`
+}
+
 type Collaborator struct {
 	Id              int          `json:"id"`
 	GrantType       string       `json:"grant_type"`

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -320,20 +320,20 @@ func (o *collaboratorBuilder) CreateAccount(
 	}
 	email = strings.TrimSpace(email)
 	if email == "" {
-		return nil, nil, nil, fmt.Errorf("baton-workato: create account: email is required")
+		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: email is required")
 	}
 
 	name, _ := profileMap["name"].(string)
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return nil, nil, nil, fmt.Errorf("baton-workato: create account: name is required")
+		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: name is required")
 	}
 
 	// Step 1: short-circuit if the collaborator already exists in this tenant.
 	if existing, err := o.client.GetCollaboratorByEmail(ctx, email); err == nil {
 		res, resErr := collaboratorResource(existing)
 		if resErr != nil {
-			return nil, nil, nil, resErr
+			return nil, nil, nil, fmt.Errorf("baton-workato: create account: build resource: %w", resErr)
 		}
 		l.Debug("collaborator already exists, returning AlreadyExistsResult", zap.String("email", email))
 		return &v2.CreateAccountResponse_AlreadyExistsResult{Resource: res}, nil, nil, nil
@@ -351,7 +351,7 @@ func (o *collaboratorBuilder) CreateAccount(
 	// 400s with "role_name or env_roles is required" just like an empty one). Fail
 	// early with a clear message instead of round-tripping to that opaque 400.
 	if len(inviteReq.EnvRoles) == 0 {
-		return nil, nil, nil, fmt.Errorf("baton-workato: create account: at least one environment role (dev_role/test_role/prod_role) is required")
+		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: at least one environment role (dev_role/test_role/prod_role) is required")
 	}
 
 	resolveEnvRoleTypes(ctx, o.client, inviteReq.EnvRoles)
@@ -389,7 +389,7 @@ func (o *collaboratorBuilder) CreateAccount(
 
 	res, err := collaboratorResource(created)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("baton-workato: create account: build resource: %w", err)
 	}
 
 	return &v2.CreateAccountResponse_SuccessResult{

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -24,7 +26,11 @@ const (
 	noAccessRoleName = "No access"
 )
 
-var _ connectorbuilder.ResourceSyncerV2 = (*collaboratorBuilder)(nil)
+var (
+	_ connectorbuilder.ResourceSyncerV2  = (*collaboratorBuilder)(nil)
+	_ connectorbuilder.AccountManagerV2  = (*collaboratorBuilder)(nil)
+	_ connectorbuilder.ResourceDeleterV2 = (*collaboratorBuilder)(nil)
+)
 
 type collaboratorBuilder struct {
 	client                 *client.WorkatoClient
@@ -274,6 +280,197 @@ func (o *collaboratorBuilder) collaboratorRoleGrants(ctx context.Context, sessio
 		rv = append(rv, newGrant)
 	}
 	return rv, nil
+}
+
+// CreateAccountCapabilityDetails declares the credential options for account
+// creation. Workato invitations are email-based and carry no password, so the
+// connector advertises the no-password option. Required for the SDK to detect
+// AccountManagerV2.
+func (o *collaboratorBuilder) CreateAccountCapabilityDetails(_ context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
+	return &v2.CredentialDetailsAccountProvisioning{
+		SupportedCredentialOptions: []v2.CapabilityDetailCredentialOption{
+			v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD,
+		},
+		PreferredCredentialOption: v2.CapabilityDetailCredentialOption_CAPABILITY_DETAIL_CREDENTIAL_OPTION_NO_PASSWORD,
+	}, nil, nil
+}
+
+// CreateAccount invites a new collaborator to Workato.
+//
+// Flow:
+//  1. If a collaborator with the email already exists in the tenant, return
+//     AlreadyExistsResult (idempotent; the account-provisioning CI re-runs create).
+//  2. Otherwise POST /api/member_invitations to send an invitation email. If the
+//     email already belongs to a Workato user (AlreadyExists), fall back to
+//     POST /api/members to add the existing user to the team directly.
+//  3. Re-resolve the collaborator by email. If they are now a member, return
+//     SuccessResult. If the invitation is still pending email acceptance (no member
+//     row yet), return ActionRequiredResult with no Resource — never fabricate a
+//     resource keyed on the email, which could not reconcile with the real
+//     ID-keyed resource a later sync emits.
+func (o *collaboratorBuilder) CreateAccount(
+	ctx context.Context, accountInfo *v2.AccountInfo, _ *v2.LocalCredentialOptions,
+) (connectorbuilder.CreateAccountResponse, []*v2.PlaintextData, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
+	profileMap := accountInfo.GetProfile().AsMap()
+
+	email := accountInfo.GetLogin()
+	if email == "" {
+		email, _ = profileMap["email"].(string)
+	}
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return nil, nil, nil, fmt.Errorf("baton-workato: create account: email is required")
+	}
+
+	name, _ := profileMap["name"].(string)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, nil, nil, fmt.Errorf("baton-workato: create account: name is required")
+	}
+
+	// Step 1: short-circuit if the collaborator already exists in this tenant.
+	if existing, err := o.client.GetCollaboratorByEmail(ctx, email); err == nil {
+		res, resErr := collaboratorResource(existing)
+		if resErr != nil {
+			return nil, nil, nil, resErr
+		}
+		l.Debug("collaborator already exists, returning AlreadyExistsResult", zap.String("email", email))
+		return &v2.CreateAccountResponse_AlreadyExistsResult{Resource: res}, nil, nil, nil
+	} else if !client.IsNotFoundError(err) {
+		return nil, nil, nil, fmt.Errorf("baton-workato: create account: failed to look up collaborator %s: %w", email, err)
+	}
+
+	// Step 2: build and send the invitation.
+	inviteReq, err := buildInviteRequest(name, email, profileMap)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	err = o.client.InviteCollaborator(ctx, inviteReq)
+	switch {
+	case err == nil:
+		// invitation sent.
+	case client.IsAlreadyExistsError(err):
+		// Email already belongs to a Workato user outside this tenant: add them directly.
+		l.Debug("invite reported already-exists, adding existing Workato user to team", zap.String("email", email))
+		if addErr := o.client.AddExistingCollaborator(ctx, email); addErr != nil {
+			if client.IsAlreadyExistsError(addErr) {
+				// Already a member after all; fall through to resolution below.
+				break
+			}
+			return nil, nil, nil, fmt.Errorf("baton-workato: create account: failed to add existing collaborator %s: %w", email, addErr)
+		}
+	default:
+		return nil, nil, nil, fmt.Errorf("baton-workato: create account: failed to invite collaborator %s: %w", email, err)
+	}
+
+	// Step 3: resolve the resulting collaborator.
+	created, err := o.client.GetCollaboratorByEmail(ctx, email)
+	if err != nil {
+		if client.IsNotFoundError(err) {
+			// Invitation sent but not yet accepted — no stable member ID exists yet.
+			return &v2.CreateAccountResponse_ActionRequiredResult{
+				Message:               fmt.Sprintf("Invitation sent to %s. The collaborator must accept the email invitation to complete account creation.", email),
+				IsCreateAccountResult: true,
+			}, nil, nil, nil
+		}
+		return nil, nil, nil, fmt.Errorf("baton-workato: create account: failed to resolve collaborator %s: %w", email, err)
+	}
+
+	res, err := collaboratorResource(created)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return &v2.CreateAccountResponse_SuccessResult{
+		Resource:              res,
+		IsCreateAccountResult: true,
+	}, nil, nil, nil
+}
+
+// Delete removes a collaborator from Workato. Workato has no soft-disable, so this
+// is a hard delete. A not-found result (HTTP 404) is treated as success because the
+// platform retries deletes and the collaborator may already be gone.
+func (o *collaboratorBuilder) Delete(ctx context.Context, resourceID *v2.ResourceId, _ *v2.ResourceId) (annotations.Annotations, error) {
+	collaboratorID, err := strconv.Atoi(resourceID.Resource)
+	if err != nil {
+		return nil, fmt.Errorf("baton-workato: delete collaborator: invalid id %q: %w", resourceID.Resource, err)
+	}
+
+	err = o.client.DeleteCollaborator(ctx, collaboratorID)
+	if err != nil {
+		if client.IsNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("baton-workato: delete collaborator %d: %w", collaboratorID, err)
+	}
+
+	return nil, nil
+}
+
+// buildInviteRequest assembles the POST /api/member_invitations body from the
+// account-creation profile. env_roles is built from per-environment role-name
+// fields (dev_role/test_role/prod_role) and user_group_ids from a comma-separated
+// string of group ids. All are optional but Workato generally needs at least one
+// role to make the invite usable, matching the official Workato Team API and the
+// connector's own UpdateCollaboratorRoles shape.
+func buildInviteRequest(name, email string, profileMap map[string]interface{}) (client.InviteCollaboratorRequest, error) {
+	req := client.InviteCollaboratorRequest{
+		Name:  name,
+		Email: email,
+	}
+
+	envRoleFields := []struct {
+		key string
+		env string
+	}{
+		{"dev_role", "dev"},
+		{"test_role", "test"},
+		{"prod_role", "prod"},
+	}
+
+	for _, f := range envRoleFields {
+		roleName := optionalStringField(profileMap, f.key)
+		if roleName == "" {
+			continue
+		}
+		req.EnvRoles = append(req.EnvRoles, client.InviteEnvRole{
+			EnvironmentType: f.env,
+			Name:            roleName,
+		})
+	}
+
+	req.UserGroupIDs = optionalStringListField(profileMap, "user_group_ids")
+
+	return req, nil
+}
+
+// optionalStringField returns a trimmed string profile field, or "" when absent.
+func optionalStringField(profileMap map[string]interface{}, key string) string {
+	raw, _ := profileMap[key].(string)
+	return strings.TrimSpace(raw)
+}
+
+// optionalStringListField parses a comma-separated string profile field into a
+// slice, trimming spaces and dropping empties. Returns a nil slice when the field
+// is absent or empty.
+func optionalStringListField(profileMap map[string]interface{}, key string) []string {
+	raw, _ := profileMap[key].(string)
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	var values []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		values = append(values, part)
+	}
+	return values
 }
 
 func newCollaboratorBuilder(client *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool) *collaboratorBuilder {

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -342,12 +342,9 @@ func (o *collaboratorBuilder) CreateAccount(
 	}
 
 	// Step 2: build and send the invitation.
-	inviteReq, err := buildInviteRequest(name, email, profileMap)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	inviteReq := buildInviteRequest(name, email, profileMap)
 
-	err = o.client.InviteCollaborator(ctx, inviteReq)
+	err := o.client.InviteCollaborator(ctx, inviteReq)
 	switch {
 	case err == nil:
 		// invitation sent.
@@ -415,7 +412,7 @@ func (o *collaboratorBuilder) Delete(ctx context.Context, resourceID *v2.Resourc
 // string of group ids. All are optional but Workato generally needs at least one
 // role to make the invite usable, matching the official Workato Team API and the
 // connector's own UpdateCollaboratorRoles shape.
-func buildInviteRequest(name, email string, profileMap map[string]interface{}) (client.InviteCollaboratorRequest, error) {
+func buildInviteRequest(name, email string, profileMap map[string]interface{}) client.InviteCollaboratorRequest {
 	req := client.InviteCollaboratorRequest{
 		Name:  name,
 		Email: email,
@@ -443,7 +440,7 @@ func buildInviteRequest(name, email string, profileMap map[string]interface{}) (
 
 	req.UserGroupIDs = optionalStringListField(profileMap, "user_group_ids")
 
-	return req, nil
+	return req
 }
 
 // optionalStringField returns a trimmed string profile field, or "" when absent.

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -341,8 +341,11 @@ func (o *collaboratorBuilder) CreateAccount(
 		return nil, nil, nil, fmt.Errorf("baton-workato: create account: failed to look up collaborator %s: %w", email, err)
 	}
 
-	// Step 2: build and send the invitation.
+	// Step 2: build and send the invitation. Tag each role's role_type by resolving
+	// the name against the environment-roles catalog; unresolved names default to
+	// privilege_group on Workato's side.
 	inviteReq := buildInviteRequest(name, email, profileMap)
+	resolveEnvRoleTypes(ctx, o.client, inviteReq.EnvRoles)
 
 	err := o.client.InviteCollaborator(ctx, inviteReq)
 	switch {
@@ -441,6 +444,49 @@ func buildInviteRequest(name, email string, profileMap map[string]interface{}) c
 	req.UserGroupIDs = optionalStringListField(profileMap, "user_group_ids")
 
 	return req
+}
+
+// environmentRoleResolver looks up an environment role by name. *client.WorkatoClient
+// satisfies it; tests use a fake. Kept narrow so resolveEnvRoleTypes is unit-testable
+// without a live API or the concrete client.
+type environmentRoleResolver interface {
+	GetEnvironmentRoleByName(ctx context.Context, name string) (*client.EnvironmentRole, annotations.Annotations, error)
+}
+
+// resolveEnvRoleTypes tags each invite role with its role_type. A role name that
+// resolves to an environment role gets RoleType "environment"; everything else is
+// left empty so Workato applies its "privilege_group" default. This brings the
+// invite path to parity with the grant flow (role.go vs environment_role.go), which
+// already distinguishes the two role types.
+//
+// Lookups are deduplicated by name and degrade gracefully: a lookup error is logged
+// and the role falls back to the privilege_group default (the connector's prior
+// behavior), so a transient environment_roles failure never breaks an otherwise
+// valid privilege-group invite.
+func resolveEnvRoleTypes(ctx context.Context, resolver environmentRoleResolver, roles []client.InviteEnvRole) {
+	l := ctxzap.Extract(ctx)
+	isEnvRole := make(map[string]bool, len(roles))
+
+	for i := range roles {
+		name := roles[i].Name
+
+		resolved, seen := isEnvRole[name]
+		if !seen {
+			envRole, _, err := resolver.GetEnvironmentRoleByName(ctx, name)
+			if err != nil {
+				l.Debug("baton-workato: create account: environment role lookup failed; defaulting to privilege_group",
+					zap.String("role_name", name), zap.Error(err))
+				isEnvRole[name] = false
+				continue
+			}
+			resolved = envRole != nil
+			isEnvRole[name] = resolved
+		}
+
+		if resolved {
+			roles[i].RoleType = roleTypeEnvironment
+		}
+	}
 }
 
 // optionalStringField returns a trimmed string profile field, or "" when absent.

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -345,6 +345,15 @@ func (o *collaboratorBuilder) CreateAccount(
 	// the name against the environment-roles catalog; unresolved names default to
 	// privilege_group on Workato's side.
 	inviteReq := buildInviteRequest(name, email, profileMap)
+
+	// Workato requires at least one environment role on every invitation — a user
+	// group does NOT satisfy it (verified against the live API: a group-only invite
+	// 400s with "role_name or env_roles is required" just like an empty one). Fail
+	// early with a clear message instead of round-tripping to that opaque 400.
+	if len(inviteReq.EnvRoles) == 0 {
+		return nil, nil, nil, fmt.Errorf("baton-workato: create account: at least one environment role (dev_role/test_role/prod_role) is required")
+	}
+
 	resolveEnvRoleTypes(ctx, o.client, inviteReq.EnvRoles)
 
 	err := o.client.InviteCollaborator(ctx, inviteReq)

--- a/pkg/connector/collaborator_test.go
+++ b/pkg/connector/collaborator_test.go
@@ -1,0 +1,97 @@
+package connector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/conductorone/baton-workato/pkg/connector/client"
+)
+
+func TestOptionalStringListField(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  map[string]interface{}
+		key      string
+		expected []string
+	}{
+		{"absent key", map[string]interface{}{}, "user_group_ids", nil},
+		{"empty string", map[string]interface{}{"user_group_ids": ""}, "user_group_ids", nil},
+		{"whitespace only", map[string]interface{}{"user_group_ids": "   "}, "user_group_ids", nil},
+		{"non-string value", map[string]interface{}{"user_group_ids": 42}, "user_group_ids", nil},
+		{"single value", map[string]interface{}{"user_group_ids": "g1"}, "user_group_ids", []string{"g1"}},
+		{"comma-separated with spaces", map[string]interface{}{"user_group_ids": " g1 , g2 ,g3"}, "user_group_ids", []string{"g1", "g2", "g3"}},
+		{"empty entries skipped", map[string]interface{}{"user_group_ids": "g1,,, g2 ,"}, "user_group_ids", []string{"g1", "g2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := optionalStringListField(tt.profile, tt.key)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("optionalStringListField() = %#v, want %#v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildInviteRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		inName   string
+		email    string
+		profile  map[string]interface{}
+		expected client.InviteCollaboratorRequest
+	}{
+		{
+			name:     "minimal — no roles, no groups",
+			inName:   "New Hire",
+			email:    "new@example.com",
+			profile:  map[string]interface{}{},
+			expected: client.InviteCollaboratorRequest{Name: "New Hire", Email: "new@example.com"},
+		},
+		{
+			name:    "all three env roles in dev/test/prod order",
+			inName:  "Admin User",
+			email:   "admin@example.com",
+			profile: map[string]interface{}{"dev_role": "Admin", "test_role": "Operator", "prod_role": "Analyst"},
+			expected: client.InviteCollaboratorRequest{
+				Name:  "Admin User",
+				Email: "admin@example.com",
+				EnvRoles: []client.InviteEnvRole{
+					{EnvironmentType: "dev", Name: "Admin"},
+					{EnvironmentType: "test", Name: "Operator"},
+					{EnvironmentType: "prod", Name: "Analyst"},
+				},
+			},
+		},
+		{
+			name:    "subset — only prod_role; empty roles skipped",
+			inName:  "Prod Only",
+			email:   "prod@example.com",
+			profile: map[string]interface{}{"dev_role": "", "prod_role": "Analyst"},
+			expected: client.InviteCollaboratorRequest{
+				Name:     "Prod Only",
+				Email:    "prod@example.com",
+				EnvRoles: []client.InviteEnvRole{{EnvironmentType: "prod", Name: "Analyst"}},
+			},
+		},
+		{
+			name:    "roles + user_group_ids together",
+			inName:  "Grouped",
+			email:   "grouped@example.com",
+			profile: map[string]interface{}{"dev_role": "Admin", "user_group_ids": " 10 , 20 "},
+			expected: client.InviteCollaboratorRequest{
+				Name:         "Grouped",
+				Email:        "grouped@example.com",
+				UserGroupIDs: []string{"10", "20"},
+				EnvRoles:     []client.InviteEnvRole{{EnvironmentType: "dev", Name: "Admin"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildInviteRequest(tt.inName, tt.email, tt.profile)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("buildInviteRequest() = %#v, want %#v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/connector/collaborator_test.go
+++ b/pkg/connector/collaborator_test.go
@@ -1,9 +1,12 @@
 package connector
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-workato/pkg/connector/client"
 )
 
@@ -93,5 +96,96 @@ func TestBuildInviteRequest(t *testing.T) {
 				t.Errorf("buildInviteRequest() = %#v, want %#v", got, tt.expected)
 			}
 		})
+	}
+}
+
+// fakeEnvRoleResolver returns an environment role for any name in envRoleNames, and
+// an error for any name in errNames (checked first), modelling a not-found as
+// (nil, nil, nil) the way the real client does.
+type fakeEnvRoleResolver struct {
+	envRoleNames map[string]bool
+	errNames     map[string]bool
+	calls        map[string]int
+}
+
+func (f *fakeEnvRoleResolver) GetEnvironmentRoleByName(_ context.Context, name string) (*client.EnvironmentRole, annotations.Annotations, error) {
+	if f.calls == nil {
+		f.calls = make(map[string]int)
+	}
+	f.calls[name]++
+	if f.errNames[name] {
+		return nil, nil, errors.New("lookup failed")
+	}
+	if f.envRoleNames[name] {
+		return &client.EnvironmentRole{Name: name}, nil, nil
+	}
+	return nil, nil, nil
+}
+
+func TestResolveEnvRoleTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		resolver  *fakeEnvRoleResolver
+		roles     []client.InviteEnvRole
+		wantTypes []string // expected RoleType per role, in order
+	}{
+		{
+			name:      "privilege-group role (not found) keeps empty role_type",
+			resolver:  &fakeEnvRoleResolver{},
+			roles:     []client.InviteEnvRole{{EnvironmentType: "dev", Name: "Admin"}},
+			wantTypes: []string{""},
+		},
+		{
+			name:      "environment role gets role_type=environment",
+			resolver:  &fakeEnvRoleResolver{envRoleNames: map[string]bool{"Deployer": true}},
+			roles:     []client.InviteEnvRole{{EnvironmentType: "prod", Name: "Deployer"}},
+			wantTypes: []string{roleTypeEnvironment},
+		},
+		{
+			name:     "mixed: env role tagged, privilege group left default",
+			resolver: &fakeEnvRoleResolver{envRoleNames: map[string]bool{"Deployer": true}},
+			roles: []client.InviteEnvRole{
+				{EnvironmentType: "dev", Name: "Admin"},
+				{EnvironmentType: "prod", Name: "Deployer"},
+			},
+			wantTypes: []string{"", roleTypeEnvironment},
+		},
+		{
+			name:      "lookup error degrades to privilege_group default",
+			resolver:  &fakeEnvRoleResolver{errNames: map[string]bool{"Flaky": true}},
+			roles:     []client.InviteEnvRole{{EnvironmentType: "dev", Name: "Flaky"}},
+			wantTypes: []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolveEnvRoleTypes(context.Background(), tt.resolver, tt.roles)
+			for i, want := range tt.wantTypes {
+				if tt.roles[i].RoleType != want {
+					t.Errorf("role[%d] (%s) RoleType = %q, want %q", i, tt.roles[i].Name, tt.roles[i].RoleType, want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveEnvRoleTypesDeduplicatesLookups(t *testing.T) {
+	resolver := &fakeEnvRoleResolver{envRoleNames: map[string]bool{"Deployer": true}}
+	roles := []client.InviteEnvRole{
+		{EnvironmentType: "dev", Name: "Deployer"},
+		{EnvironmentType: "test", Name: "Deployer"},
+		{EnvironmentType: "prod", Name: "Deployer"},
+	}
+
+	resolveEnvRoleTypes(context.Background(), resolver, roles)
+
+	for i := range roles {
+		if roles[i].RoleType != roleTypeEnvironment {
+			t.Errorf("role[%d] RoleType = %q, want %q", i, roles[i].RoleType, roleTypeEnvironment)
+		}
+	}
+	if got := resolver.calls["Deployer"]; got != 1 {
+		t.Errorf("GetEnvironmentRoleByName called %d times for %q, want 1 (deduplicated)", got, "Deployer")
 	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -73,7 +73,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 				"dev_role": {
 					DisplayName: "Development Role",
 					Required:    false,
-					Description: "Workato role NAME to assign in the Development environment, e.g. \"Admin\", \"Operator\" or \"Analyst\".",
+					Description: "Workato role NAME for the Development environment — privilege-group (e.g. \"Admin\") or environment role; type detected automatically.",
 					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
 						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
 					},
@@ -83,7 +83,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 				"test_role": {
 					DisplayName: "Test Role",
 					Required:    false,
-					Description: "Workato role NAME to assign in the Test environment, e.g. \"Admin\", \"Operator\" or \"Analyst\".",
+					Description: "Workato role NAME for the Test environment — privilege-group (e.g. \"Operator\") or environment role; type detected automatically.",
 					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
 						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
 					},
@@ -93,7 +93,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 				"prod_role": {
 					DisplayName: "Production Role",
 					Required:    false,
-					Description: "Workato role NAME to assign in the Production environment, e.g. \"Admin\", \"Operator\" or \"Analyst\".",
+					Description: "Workato role NAME for the Production environment — privilege-group (e.g. \"Analyst\") or environment role; type detected automatically.",
 					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
 						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
 					},

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -48,6 +48,70 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 	return &v2.ConnectorMetadata{
 		DisplayName: "Workato",
 		Description: "Connector to sync collaborators, project, folders, roles and privileges from Workato.",
+		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
+			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
+				"email": {
+					DisplayName: "Email",
+					Required:    true,
+					Description: "Email address of the collaborator to invite.",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "jane.doe@example.com",
+					Order:       1,
+				},
+				"name": {
+					DisplayName: "Name",
+					Required:    true,
+					Description: "Full name of the collaborator to invite.",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "Jane Doe",
+					Order:       2,
+				},
+				"dev_role": {
+					DisplayName: "Development Role",
+					Required:    false,
+					Description: "Workato role NAME to assign in the Development environment, e.g. \"Admin\", \"Operator\" or \"Analyst\".",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "Admin",
+					Order:       3,
+				},
+				"test_role": {
+					DisplayName: "Test Role",
+					Required:    false,
+					Description: "Workato role NAME to assign in the Test environment, e.g. \"Admin\", \"Operator\" or \"Analyst\".",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "Operator",
+					Order:       4,
+				},
+				"prod_role": {
+					DisplayName: "Production Role",
+					Required:    false,
+					Description: "Workato role NAME to assign in the Production environment, e.g. \"Admin\", \"Operator\" or \"Analyst\".",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "Analyst",
+					Order:       5,
+				},
+				"user_group_ids": {
+					DisplayName: "User Group IDs",
+					Required:    false,
+					Description: "Comma-separated list of Workato user group string IDs to add the collaborator to, e.g. \"am-WxEKCibh-dTXBtz\".",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
+						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+					},
+					Placeholder: "am-WxEKCibh-dTXBtz,am-AbCdEfGh-iJkLmNo",
+					Order:       6,
+				},
+			},
+		},
 	}, nil
 }
 
@@ -79,6 +143,11 @@ func New(ctx context.Context, config *cfg.Workato, _ *cli.ConnectorOpts) (connec
 	}
 
 	dataCenterUrl := client.WorkatoDataCenters[config.WorkatoDataCenter]
+	// base-url override: empty in production (use the data center), set only for
+	// self-hosted proxies or integration tests against cmd/test-server.
+	if config.WorkatoBaseUrl != "" {
+		dataCenterUrl = config.WorkatoBaseUrl
+	}
 
 	env, err := workato.EnvFromString(config.WorkatoEnv)
 	if err != nil {


### PR DESCRIPTION
## INTENT (acceptance criteria — verbatim)
> Collaborators (Workato's term for user accounts) — add invite (create), keep existing update, and add delete.
>
> Why: Workato runs DraftKings's iPaaS integrations; collaborator access is a controlled change surface for production data pipelines. Today the connector can adjust role bindings on existing collaborators but cannot invite new ones or remove leavers, so AC-2(a)/(h) controls require manual Workato admin work. Adding invite and delete brings Workato to parity with the other automation-platform connectors and removes a recurring offboarding step.

## What
- **CreateAccount** — `POST /api/member_invitations`; returns `AlreadyExistsResult` when the collaborator already exists and `ActionRequiredResult` when the invite is still pending email acceptance (Workato invites are async — a member only materializes after the invitee accepts).
- **Delete** — `DELETE /api/members/{id}`; not-found is treated as idempotent success. Workato has no soft-disable, so delete is the deprovision.
- **AccountCreationSchema** + `CreateAccountCapabilityDetails` (no-password) so the SDK detects `AccountManagerV2`. Regenerated `baton_capabilities.json` (ACCOUNT_PROVISIONING + RESOURCE_DELETE).
- The existing role update (`UpdateCollaboratorRoles`) is unchanged.

## Testing
Workato account creation is asynchronous (the invited collaborator must accept an email before becoming a queryable/deletable member), so a live full-cycle run can't be automated. Added an in-process mock instead:
- **`cmd/test-server/`** — mocks the Workato Team API (members invite/list/delete/update-roles, roles, projects, folders), Bearer auth, `{message}` error envelope, 404-on-missing-delete, 400 when an invite carries no role/group. It collapses the async invite into immediate membership so CI can exercise **create → sync → delete**; the connector's pending-invite path is exercised against the live API.
- **`workato-base-url`** — optional config override (empty default = data-center selection, production unchanged) so the connector can target the test server. Regenerated `conf.gen.go` + `config_schema.json`.
- **`ci.yaml`** — new credential-free `account-provisioning-test` job (test server + `account-provisioning@v4`). The existing real-API role job is untouched.

Verified locally with `baton-test`: full **create → sync → delete → idempotent delete → verified deletion** passes against the test server; sync is green (collaborators, roles, privileges, projects, folders). `go build ./...`, `go vet`, `gofmt`, `go test ./...` all pass.

Fixes CXH-1494

🤖 Generated with [Claude Code](https://claude.com/claude-code)