### PR TITLE
[CXP-705][CXP-541] Fix 401 errors on roles and environment roles sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ You must be an Admin or have a role with access to API Clients.
 |              | Collaborators        | Get collaborator privileges | `GET /api/members/:id/privileges`  |
 |              | Collaborator roles   | List non-system roles       | `GET /api/roles`                   |
 
+> **Note:** The **Collaborator roles** section (including "List non-system roles") only appears in the API client permissions UI if your workspace still uses the legacy roles model. If this section is not visible, your workspace has migrated to the new RBAC v2 model (Environment roles + Project roles). In that case, legacy custom roles are not accessible via the API and you should either:
+> - Migrate your legacy custom roles to the new model using the [Role migration API](https://docs.workato.com/workato-api/role-migration.html), or
+> - Set `--disable-custom-roles-sync=true` to skip legacy custom role sync and continue with base and environment roles only.
+
 ### Using Workato commercial platform:
 
 Generate an API KEY:

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -43,7 +43,7 @@ Select the following endpoints:
     |              | Collaborators        | Add existing collaborator   | `POST /api/members`                |
     |              | Collaborators        | Remove collaborator         | `DELETE /api/members/:id`          |
     |              | Collaborators        | Get collaborator privileges | `GET /api/members/:id/privileges`  |
-    |              | Collaborator roles   | List non-system roles       | `GET /api/roles`                   |
+    |              | Collaborator roles   | List non-system roles§      | `GET /api/roles`                   |
     |              | Environment roles    | List environment roles†     | `GET /api/environment_roles`       |
     |              | Environment roles    | Get environment role†‡      | `GET /api/environment_roles/:id`   |
     *If you don’t want to use C1 to provision role assignments, you can skip **Update collaborator’s roles** and **Get environment role**.
@@ -51,6 +51,8 @@ Select the following endpoints:
     †**List environment roles** and **Get environment role** are only available in workspaces that use the new RBAC v2 model (environment roles). If your workspace uses the legacy role model, these permissions do not appear in the UI and you can skip them.
 
     ‡**Get environment role** is required only if you want C1 to provision environment role assignments.
+
+    §**The Collaborator roles section** (including **List non-system roles**) only appears in the UI if your workspace uses the legacy roles model. If this section is not visible, your workspace has migrated to the new RBAC v2 model and legacy custom roles are no longer accessible via the API. In that case, migrate your legacy custom roles to environment roles using the [Role migration API](https://docs.workato.com/workato-api/role-migration.html), or enable **Disable custom roles sync** to skip legacy custom role sync.
 </Step>
 <Step>
 Save the new role.  
@@ -232,7 +234,8 @@ stringData:
   BATON_WORKATO_DATA_CENTER: <Your Workato data center (one of us, eu, jp, sg, or au). Default is us.>
   BATON_WORKATO_ENV: <Your Workato environment (one of dev, test, or prod). Default is 'dev'>
 
-  # Optional: include if you don't want to sync custom Workato roles
+  # Optional: set to true to skip legacy custom role sync (required if your workspace
+  # has migrated to RBAC v2 and the 'Collaborator roles' section does not appear in the API client UI)
   BATON_DISABLE_CUSTOM_ROLES_SYNC: true
 
   # Optional: include if you want C1 to provision access using this connector

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -37,6 +37,7 @@ type collaboratorBuilder struct {
 	cache                  *collaboratorCache
 	env                    workato.Environment
 	disableCustomRolesSync bool
+	syncEnvironmentRoles   bool
 }
 
 func (o *collaboratorBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -195,6 +196,9 @@ func (o *collaboratorBuilder) collaboratorRoleGrants(ctx context.Context, sessio
 
 		switch role.RoleType {
 		case roleTypeEnvironment:
+			if !o.syncEnvironmentRoles {
+				continue
+			}
 			envRole, err := getEnvironmentRoleByName(ctx, session, role.RoleName)
 			if err != nil {
 				return nil, err
@@ -525,12 +529,13 @@ func optionalStringListField(profileMap map[string]interface{}, key string) []st
 	return values
 }
 
-func newCollaboratorBuilder(client *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool) *collaboratorBuilder {
+func newCollaboratorBuilder(client *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool, syncEnvironmentRoles bool) *collaboratorBuilder {
 	return &collaboratorBuilder{
 		client:                 client,
 		cache:                  newCollaboratorCache(client),
 		env:                    env,
 		disableCustomRolesSync: disableCustomRolesSync,
+		syncEnvironmentRoles:   syncEnvironmentRoles,
 	}
 }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -28,17 +28,14 @@ type Connector struct {
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
-	syncers := []connectorbuilder.ResourceSyncerV2{
+	return []connectorbuilder.ResourceSyncerV2{
+		newEnvironmentRoleBuilder(d.client, d.env),
 		newCollaboratorBuilder(d.client, d.env, d.disableCustomRolesSync, d.syncEnvironmentRoles),
 		newPrivilegeBuilder(d.client),
 		newRoleBuilder(d.client, d.env, d.disableCustomRolesSync),
 		newFolderBuilder(d.client, d.disableCustomRolesSync),
 		newProjectBuilder(d.client),
 	}
-	if d.syncEnvironmentRoles {
-		syncers = append([]connectorbuilder.ResourceSyncerV2{newEnvironmentRoleBuilder(d.client, d.env)}, syncers...)
-	}
-	return syncers
 }
 
 // Asset takes an input AssetRef and attempts to fetch it using the connector's authenticated http client

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -23,18 +23,22 @@ type Connector struct {
 	client                 *client.WorkatoClient
 	env                    workato.Environment
 	disableCustomRolesSync bool
+	syncEnvironmentRoles   bool
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
-	return []connectorbuilder.ResourceSyncerV2{
-		newCollaboratorBuilder(d.client, d.env, d.disableCustomRolesSync),
+	syncers := []connectorbuilder.ResourceSyncerV2{
+		newCollaboratorBuilder(d.client, d.env, d.disableCustomRolesSync, d.syncEnvironmentRoles),
 		newPrivilegeBuilder(d.client),
 		newRoleBuilder(d.client, d.env, d.disableCustomRolesSync),
-		newEnvironmentRoleBuilder(d.client, d.env),
 		newFolderBuilder(d.client, d.disableCustomRolesSync),
 		newProjectBuilder(d.client),
 	}
+	if d.syncEnvironmentRoles {
+		syncers = append([]connectorbuilder.ResourceSyncerV2{newEnvironmentRoleBuilder(d.client, d.env)}, syncers...)
+	}
+	return syncers
 }
 
 // Asset takes an input AssetRef and attempts to fetch it using the connector's authenticated http client
@@ -126,16 +130,17 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func NewConnector(ctx context.Context, workatoClient *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool) (*Connector, error) {
+func NewConnector(ctx context.Context, workatoClient *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool, syncEnvironmentRoles bool) (*Connector, error) {
 	return &Connector{
 		client:                 workatoClient,
 		env:                    env,
 		disableCustomRolesSync: disableCustomRolesSync,
+		syncEnvironmentRoles:   syncEnvironmentRoles,
 	}, nil
 }
 
 // New returns the Workato connector configured to sync against the instance URL.
-func New(ctx context.Context, config *cfg.Workato, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+func New(ctx context.Context, config *cfg.Workato, connectorOpts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	l := ctxzap.Extract(ctx)
 	err := field.Validate(cfg.Config, config)
 	if err != nil {
@@ -159,7 +164,8 @@ func New(ctx context.Context, config *cfg.Workato, _ *cli.ConnectorOpts) (connec
 		return nil, nil, err
 	}
 
-	cb, err := NewConnector(ctx, workatoClient, env, config.DisableCustomRolesSync)
+	syncEnvRoles := connectorOpts != nil && connectorOpts.WillSyncResourceType(environmentRoleResourceType.Id)
+	cb, err := NewConnector(ctx, workatoClient, env, config.DisableCustomRolesSync, syncEnvRoles)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, nil, err

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -44,6 +44,12 @@ func (o *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, attr rs.SyncOp
 	if !o.disableCustomRolesSync {
 		roles, nextToken, annos, err := o.client.GetRoles(ctx, attr.PageToken.Token)
 		if err != nil {
+			if code := status.Code(err); code == codes.Unauthenticated || code == codes.PermissionDenied {
+				return nil, &rs.SyncOpResults{Annotations: annos}, fmt.Errorf(
+					"baton-workato: API client is not authorized to list legacy custom roles. "+
+						"Grant the 'List non-system roles' privilege to the API client in Workato, "+
+						"or set --disable-custom-roles-sync=true to skip legacy custom role sync and continue with base roles only, and environment roles if enabled: %w", err)
+			}
 			return nil, &rs.SyncOpResults{Annotations: annos}, err
 		}
 


### PR DESCRIPTION
Surface an actionable error when GET /api/roles returns 401/403 (CXP-705): the previous message pointed at a JSON deserialization detail instead of the missing privilege. The new error names the problem and points to --disable-custom-roles-sync as recovery.

Gate environment role sync behind WillSyncResourceType (CXP-541): skip environmentRoleBuilder registration and environment role lookups in collaborator grants when the resource type is excluded, preventing 401 crashes when the API client lacks environment roles access.

Update README and connector.mdx to document the RBAC v2 migration path.

#### Description

- [ ] Bug fix
- [ ] New feature




#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
