### PR TITLE
docs: document account provisioning env role requirement (connector.mdx)

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -292,3 +292,22 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 
 </Tab>
 </Tabs>
+
+## Provision accounts
+
+When you use C1 to provision access in Workato, C1 creates the collaborator by sending a Workato member invitation. The invited person receives an email and becomes a full member once they accept it.
+
+### Required attributes
+
+Configure the account-provisioning attribute mapping in C1 with at least these attributes:
+
+| Attribute | Required | Notes |
+| :--- | :--- | :--- |
+| `email` | Yes | The collaborator's email address. |
+| `name` | Yes | The collaborator's full name. |
+| `dev_role` / `test_role` / `prod_role` | At least one | The environment role to assign, per environment. Workato requires at least one environment role on every invitation — a user group alone is not sufficient. |
+| `user_group_ids` | No | Comma-separated Workato user group IDs. |
+
+<Note>
+The environment role you map must target an environment that **exists in your Workato workspace**. Workspaces may have only a subset of environments (for example, only **dev**). Mapping a role for an environment your workspace does not have causes the invitation to fail with `Environment <env> not found`. Use the role field (`dev_role`, `test_role`, or `prod_role`) that matches an environment your workspace actually has.
+</Note>


### PR DESCRIPTION
## Summary

Adds a **Provision accounts** section to the Workato connector docs. The published docs (`docs/connector.mdx` → conductorone.com/docs/baton/workato) cover setup, credentials, and configuration but do not document account provisioning, so an operator gets no guidance on which attributes to map or that an environment role is required — the first provisioning attempt is approved and then fails at runtime.

## What it documents

- `email` and `name` are required.
- At least one of `dev_role` / `test_role` / `prod_role` is required — Workato requires an environment role on every member invitation (a user group alone is not sufficient; `env_roles` is required per the [Workato Team API](https://docs.workato.com/workato-api/team.html)).
- `user_group_ids` is optional.
- The mapped environment role must target an environment the workspace actually has; mapping a role for a non-existent environment fails with `Environment <env> not found`.

## Context

Fills the documentation gap surfaced during CXH-1494 validation. Resolves the documentation half of CXH-1957. Not in scope here: the schema/UX side of CXH-1957 and the login-as-email bug CXH-1958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)