### PR TITLE
[CXH-1957][CXH-1958] - Require env_roles list + fix CreateAccount invite email

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
           connector: ./baton-workato
           account-email: newhire@example.com
           account-login: newhire@example.com
-          account-profile: '{"name":"New Hire","email":"newhire@example.com","dev_role":"Admin"}'
+          account-profile: '{"name":"New Hire","email":"newhire@example.com","env_roles":["dev:Admin"]}'
           account-type: collaborator
           search-method: email
       - name: Stop test server

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -6,6 +6,37 @@ description: C1 provides identity governance and just-in-time provisioning for W
 sidebarTitle: Workato
 ---
 
+## Provision accounts
+
+When provisioning a new collaborator account, the following fields are available on the account creation form:
+
+| Field | Required | Description |
+| :---- | :------- | :---------- |
+| **Email** | Yes | Email address of the collaborator to invite. |
+| **Name** | Yes | Full name of the collaborator. |
+| **Environment Roles** | Yes | List of environment + role assignments. Each entry must be in `env:role` format (e.g. `dev:Admin`, `prod:Analyst`). At least one entry is required. |
+| **User Group IDs** | No | Comma-separated list of Workato user group IDs to add the collaborator to. |
+
+### Environment Roles format
+
+Each entry in **Environment Roles** encodes the target environment and the role name separated by a colon:
+
+```
+<environment>:<role name>
+```
+
+Allowed environment values are `dev`, `test`, and `prod`. The role name must match an existing role (privilege-group or environment role) in your Workato workspace.
+
+Examples:
+
+- `dev:Admin` — assign the Admin role in the Development environment
+- `prod:Analyst` — assign the Analyst role in the Production environment
+- `test:Operator` — assign the Operator role in the Test environment
+
+<Warning>
+The role must target an environment that the workspace has provisioned. If the workspace does not have the specified environment, the invitation fails with `Environment <env> not found`.
+</Warning>
+
 ## Capabilities
 
 | Resource     | Sync | Provision |

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -351,7 +351,12 @@ func (o *collaboratorBuilder) CreateAccount(
 	// a specific, actionable error rather than the opaque "at least one
 	// environment role is required" below.
 	if len(malformedEnvRoles) > 0 {
-		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: malformed env_roles entries %v (expected \"env:role\" with env one of dev, test, prod)", malformedEnvRoles)
+		return nil, nil, nil, status.Errorf(
+			codes.InvalidArgument,
+			"baton-workato: create account: malformed env_roles entries %v "+
+				"(expected \"env:role\" with env one of dev, test, prod)",
+			malformedEnvRoles,
+		)
 	}
 
 	// Workato requires at least one environment role on every invitation — a user

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -356,7 +356,7 @@ func (o *collaboratorBuilder) CreateAccount(
 	// 400s with "role_name or env_roles is required" just like an empty one). Fail
 	// early with a clear message instead of round-tripping to that opaque 400.
 	if len(inviteReq.EnvRoles) == 0 {
-		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: at least one environment role (dev_role/test_role/prod_role) is required")
+		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: at least one environment role is required (map env_roles as \"env:role\", e.g. \"dev:Admin\")")
 	}
 
 	resolveEnvRoleTypes(ctx, o.client, inviteReq.EnvRoles)
@@ -424,35 +424,34 @@ func (o *collaboratorBuilder) Delete(ctx context.Context, resourceID *v2.Resourc
 }
 
 // buildInviteRequest assembles the POST /api/member_invitations body from the
-// account-creation profile. env_roles is built from per-environment role-name
-// fields (dev_role/test_role/prod_role) and user_group_ids from a comma-separated
-// string of group ids. All are optional but Workato generally needs at least one
-// role to make the invite usable, matching the official Workato Team API and the
-// connector's own UpdateCollaboratorRoles shape.
+// account-creation profile. env_roles is a required list where each entry is in
+// "env:role" format (e.g. "dev:Admin", "prod:Analyst"). Allowed environment
+// prefixes are dev, test, and prod; entries with unknown prefixes or no colon
+// are silently skipped. user_group_ids is an optional comma-separated string of
+// group IDs. The shape reuses client.InviteEnvRole{EnvironmentType, Name}.
 func buildInviteRequest(name, email string, profileMap map[string]interface{}) client.InviteCollaboratorRequest {
 	req := client.InviteCollaboratorRequest{
 		Name:  name,
 		Email: email,
 	}
 
-	envRoleFields := []struct {
-		key string
-		env string
-	}{
-		{"dev_role", "dev"},
-		{"test_role", "test"},
-		{"prod_role", "prod"},
-	}
-
-	for _, f := range envRoleFields {
-		roleName := optionalStringField(profileMap, f.key)
+	for _, entry := range optionalStringListField(profileMap, "env_roles") {
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		envPart := strings.ToLower(strings.TrimSpace(parts[0]))
+		roleName := strings.TrimSpace(parts[1])
 		if roleName == "" {
 			continue
 		}
-		req.EnvRoles = append(req.EnvRoles, client.InviteEnvRole{
-			EnvironmentType: f.env,
-			Name:            roleName,
-		})
+		switch envPart {
+		case "dev", "test", "prod":
+			req.EnvRoles = append(req.EnvRoles, client.InviteEnvRole{
+				EnvironmentType: envPart,
+				Name:            roleName,
+			})
+		}
 	}
 
 	req.UserGroupIDs = optionalStringListField(profileMap, "user_group_ids")
@@ -509,25 +508,45 @@ func optionalStringField(profileMap map[string]interface{}, key string) string {
 	return strings.TrimSpace(raw)
 }
 
-// optionalStringListField parses a comma-separated string profile field into a
-// slice, trimming spaces and dropping empties. Returns a nil slice when the field
-// is absent or empty.
+// optionalStringListField parses a profile field into a slice, trimming spaces
+// and dropping empties. It handles two wire formats:
+//   - []interface{} — produced by structpb.Struct.AsMap() for StringListField
+//     values; each element is type-asserted to string.
+//   - string — comma-separated (used by user_group_ids and legacy callers).
+//
+// Returns a nil slice when the field is absent or empty.
 func optionalStringListField(profileMap map[string]interface{}, key string) []string {
-	raw, _ := profileMap[key].(string)
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
+	raw, ok := profileMap[key]
+	if !ok {
 		return nil
 	}
-
-	var values []string
-	for _, part := range strings.Split(raw, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
+	switch v := raw.(type) {
+	case []interface{}:
+		var values []string
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				if s = strings.TrimSpace(s); s != "" {
+					values = append(values, s)
+				}
+			}
 		}
-		values = append(values, part)
+		return values
+	case string:
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return nil
+		}
+		var values []string
+		for _, part := range strings.Split(v, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				values = append(values, part)
+			}
+		}
+		return values
+	default:
+		return nil
 	}
-	return values
 }
 
 // resolveInviteEmail picks the best email address to use for a Workato

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -344,7 +344,15 @@ func (o *collaboratorBuilder) CreateAccount(
 	// Step 2: build and send the invitation. Tag each role's role_type by resolving
 	// the name against the environment-roles catalog; unresolved names default to
 	// privilege_group on Workato's side.
-	inviteReq := buildInviteRequest(name, email, profileMap)
+	inviteReq, malformedEnvRoles := buildInviteRequest(name, email, profileMap)
+
+	// Name the bad entries instead of silently dropping them, so a mapping that
+	// only supplies malformed values (e.g. "Admin" or "staging:Admin") fails with
+	// a specific, actionable error rather than the opaque "at least one
+	// environment role is required" below.
+	if len(malformedEnvRoles) > 0 {
+		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: malformed env_roles entries %v (expected \"env:role\" with env one of dev, test, prod)", malformedEnvRoles)
+	}
 
 	// Workato requires at least one environment role on every invitation — a user
 	// group does NOT satisfy it (verified against the live API: a group-only invite
@@ -424,20 +432,23 @@ func (o *collaboratorBuilder) Delete(ctx context.Context, resourceID *v2.Resourc
 // prefixes are dev, test, and prod; entries with unknown prefixes or no colon
 // are silently skipped. user_group_ids is an optional comma-separated string of
 // group IDs. The shape reuses client.InviteEnvRole{EnvironmentType, Name}.
-func buildInviteRequest(name, email string, profileMap map[string]interface{}) client.InviteCollaboratorRequest {
+func buildInviteRequest(name, email string, profileMap map[string]interface{}) (client.InviteCollaboratorRequest, []string) {
 	req := client.InviteCollaboratorRequest{
 		Name:  name,
 		Email: email,
 	}
 
+	var malformed []string
 	for _, entry := range optionalStringListField(profileMap, "env_roles") {
 		parts := strings.SplitN(entry, ":", 2)
 		if len(parts) != 2 {
+			malformed = append(malformed, entry)
 			continue
 		}
 		envPart := strings.ToLower(strings.TrimSpace(parts[0]))
 		roleName := strings.TrimSpace(parts[1])
 		if roleName == "" {
+			malformed = append(malformed, entry)
 			continue
 		}
 		switch envPart {
@@ -446,12 +457,14 @@ func buildInviteRequest(name, email string, profileMap map[string]interface{}) c
 				EnvironmentType: envPart,
 				Name:            roleName,
 			})
+		default:
+			malformed = append(malformed, entry)
 		}
 	}
 
 	req.UserGroupIDs = optionalStringListField(profileMap, "user_group_ids")
 
-	return req
+	return req, malformed
 }
 
 // environmentRoleResolver looks up an environment role by name. *client.WorkatoClient
@@ -553,7 +566,7 @@ func optionalStringListField(profileMap map[string]interface{}, key string) []st
 // Workato's invite API, which rejects non-email values with "400 Email is invalid".
 func resolveInviteEmail(login string, emails []*v2.AccountInfo_Email, profileMap map[string]interface{}) string {
 	// Prefer the explicitly-mapped profile field.
-	if mapped := strings.TrimSpace(optionalStringField(profileMap, "email")); mapped != "" {
+	if mapped := optionalStringField(profileMap, "email"); mapped != "" {
 		return mapped
 	}
 	// Use login only when it looks like an email address.

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -434,8 +434,9 @@ func (o *collaboratorBuilder) Delete(ctx context.Context, resourceID *v2.Resourc
 // buildInviteRequest assembles the POST /api/member_invitations body from the
 // account-creation profile. env_roles is a required list where each entry is in
 // "env:role" format (e.g. "dev:Admin", "prod:Analyst"). Allowed environment
-// prefixes are dev, test, and prod; entries with unknown prefixes or no colon
-// are silently skipped. user_group_ids is an optional comma-separated string of
+// prefixes are dev, test, and prod; entries with unknown prefixes, no colon, or
+// an empty role are collected as malformed and cause CreateAccount to fail with
+// InvalidArgument. user_group_ids is an optional comma-separated string of
 // group IDs. The shape reuses client.InviteEnvRole{EnvironmentType, Name}.
 func buildInviteRequest(name, email string, profileMap map[string]interface{}) (client.InviteCollaboratorRequest, []string) {
 	req := client.InviteCollaboratorRequest{

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -318,11 +318,12 @@ func (o *collaboratorBuilder) CreateAccount(
 	l := ctxzap.Extract(ctx)
 	profileMap := accountInfo.GetProfile().AsMap()
 
-	email := accountInfo.GetLogin()
-	if email == "" {
-		email, _ = profileMap["email"].(string)
+	var emailAddresses []string
+	for _, e := range accountInfo.GetEmails() {
+		emailAddresses = append(emailAddresses, e.GetAddress())
 	}
-	email = strings.TrimSpace(email)
+
+	email := resolveInviteEmail(accountInfo.GetLogin(), emailAddresses, profileMap)
 	if email == "" {
 		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: email is required")
 	}
@@ -527,6 +528,38 @@ func optionalStringListField(profileMap map[string]interface{}, key string) []st
 		values = append(values, part)
 	}
 	return values
+}
+
+// resolveInviteEmail picks the best email address to use for a Workato
+// invitation. It prefers the explicitly-mapped "email" profile field (which C1
+// populates from the directory user's real email), then falls back to the login
+// only when it is email-shaped, and lastly to the first address from GetEmails().
+// This avoids sending a bare username handle to Workato's invite API, which
+// rejects non-email values with "400 Email is invalid".
+func resolveInviteEmail(login string, emailAddresses []string, profileMap map[string]interface{}) string {
+	// Prefer the explicitly-mapped profile field.
+	if mapped := strings.TrimSpace(optionalStringField(profileMap, "email")); mapped != "" {
+		return mapped
+	}
+	// Use login only when it looks like an email address.
+	if trimmed := strings.TrimSpace(login); isEmailShaped(trimmed) {
+		return trimmed
+	}
+	// Last resort: first non-empty address from accountInfo.GetEmails().
+	for _, addr := range emailAddresses {
+		if addr = strings.TrimSpace(addr); addr != "" {
+			return addr
+		}
+	}
+	return ""
+}
+
+// isEmailShaped returns true when s contains a non-empty local part, an "@",
+// and a non-empty domain part. It is intentionally lenient — the goal is only
+// to distinguish bare username handles (no "@") from plausible email strings.
+func isEmailShaped(s string) bool {
+	at := strings.LastIndex(s, "@")
+	return at > 0 && at < len(s)-1
 }
 
 func newCollaboratorBuilder(client *client.WorkatoClient, env workato.Environment, disableCustomRolesSync bool, syncEnvironmentRoles bool) *collaboratorBuilder {

--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -318,12 +318,7 @@ func (o *collaboratorBuilder) CreateAccount(
 	l := ctxzap.Extract(ctx)
 	profileMap := accountInfo.GetProfile().AsMap()
 
-	var emailAddresses []string
-	for _, e := range accountInfo.GetEmails() {
-		emailAddresses = append(emailAddresses, e.GetAddress())
-	}
-
-	email := resolveInviteEmail(accountInfo.GetLogin(), emailAddresses, profileMap)
+	email := resolveInviteEmail(accountInfo.GetLogin(), accountInfo.GetEmails(), profileMap)
 	if email == "" {
 		return nil, nil, nil, status.Errorf(codes.InvalidArgument, "baton-workato: create account: email is required")
 	}
@@ -552,10 +547,11 @@ func optionalStringListField(profileMap map[string]interface{}, key string) []st
 // resolveInviteEmail picks the best email address to use for a Workato
 // invitation. It prefers the explicitly-mapped "email" profile field (which C1
 // populates from the directory user's real email), then falls back to the login
-// only when it is email-shaped, and lastly to the first address from GetEmails().
-// This avoids sending a bare username handle to Workato's invite API, which
-// rejects non-email values with "400 Email is invalid".
-func resolveInviteEmail(login string, emailAddresses []string, profileMap map[string]interface{}) string {
+// only when it is email-shaped, and lastly to the addresses from GetEmails() —
+// preferring the primary (IsPrimary == true) entry when present, otherwise the
+// first non-empty address. This avoids sending a bare username handle to
+// Workato's invite API, which rejects non-email values with "400 Email is invalid".
+func resolveInviteEmail(login string, emails []*v2.AccountInfo_Email, profileMap map[string]interface{}) string {
 	// Prefer the explicitly-mapped profile field.
 	if mapped := strings.TrimSpace(optionalStringField(profileMap, "email")); mapped != "" {
 		return mapped
@@ -564,13 +560,21 @@ func resolveInviteEmail(login string, emailAddresses []string, profileMap map[st
 	if trimmed := strings.TrimSpace(login); isEmailShaped(trimmed) {
 		return trimmed
 	}
-	// Last resort: first non-empty address from accountInfo.GetEmails().
-	for _, addr := range emailAddresses {
-		if addr = strings.TrimSpace(addr); addr != "" {
+	// Last resort: prefer primary email from GetEmails(), fall back to first non-empty.
+	var first string
+	for _, e := range emails {
+		addr := strings.TrimSpace(e.GetAddress())
+		if addr == "" {
+			continue
+		}
+		if e.GetIsPrimary() {
 			return addr
 		}
+		if first == "" {
+			first = addr
+		}
 	}
-	return ""
+	return first
 }
 
 // isEmailShaped returns true when s contains a non-empty local part, an "@",

--- a/pkg/connector/collaborator_test.go
+++ b/pkg/connector/collaborator_test.go
@@ -84,6 +84,7 @@ func TestOptionalStringListField(t *testing.T) {
 		key      string
 		expected []string
 	}{
+		// string (comma-separated) wire format
 		{"absent key", map[string]interface{}{}, "user_group_ids", nil},
 		{"empty string", map[string]interface{}{"user_group_ids": ""}, "user_group_ids", nil},
 		{"whitespace only", map[string]interface{}{"user_group_ids": "   "}, "user_group_ids", nil},
@@ -91,6 +92,12 @@ func TestOptionalStringListField(t *testing.T) {
 		{"single value", map[string]interface{}{"user_group_ids": "g1"}, "user_group_ids", []string{"g1"}},
 		{"comma-separated with spaces", map[string]interface{}{"user_group_ids": " g1 , g2 ,g3"}, "user_group_ids", []string{"g1", "g2", "g3"}},
 		{"empty entries skipped", map[string]interface{}{"user_group_ids": "g1,,, g2 ,"}, "user_group_ids", []string{"g1", "g2"}},
+		// []interface{} wire format — produced by structpb.Struct.AsMap() for StringListField values
+		{"native list", map[string]interface{}{"env_roles": []interface{}{"dev:Admin", "prod:Analyst"}}, "env_roles", []string{"dev:Admin", "prod:Analyst"}},
+		{"native list with blank entry", map[string]interface{}{"env_roles": []interface{}{"", "dev:Admin"}}, "env_roles", []string{"dev:Admin"}},
+		{"native list with whitespace entry", map[string]interface{}{"env_roles": []interface{}{"  ", "dev:Admin"}}, "env_roles", []string{"dev:Admin"}},
+		{"native list non-string element skipped", map[string]interface{}{"env_roles": []interface{}{42, "dev:Admin"}}, "env_roles", []string{"dev:Admin"}},
+		{"native list all empty", map[string]interface{}{"env_roles": []interface{}{"", ""}}, "env_roles", nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -111,20 +118,37 @@ func TestBuildInviteRequest(t *testing.T) {
 		expected client.InviteCollaboratorRequest
 	}{
 		{
-			name:     "minimal — no roles, no groups",
+			name:     "minimal — no env_roles field",
 			inName:   "New Hire",
 			email:    "new@example.com",
 			profile:  map[string]interface{}{},
 			expected: client.InviteCollaboratorRequest{Name: "New Hire", Email: "new@example.com"},
 		},
 		{
-			name:    "all three env roles in dev/test/prod order",
-			inName:  "Admin User",
-			email:   "admin@example.com",
-			profile: map[string]interface{}{"dev_role": "Admin", "test_role": "Operator", "prod_role": "Analyst"},
+			// Native list format: structpb.Struct.AsMap() produces []interface{} for StringListField.
+			name:   "single entry dev:Admin via native list",
+			inName: "Admin User",
+			email:  "admin@example.com",
+			profile: map[string]interface{}{
+				"env_roles": []interface{}{"dev:Admin"},
+			},
 			expected: client.InviteCollaboratorRequest{
-				Name:  "Admin User",
-				Email: "admin@example.com",
+				Name:     "Admin User",
+				Email:    "admin@example.com",
+				EnvRoles: []client.InviteEnvRole{{EnvironmentType: "dev", Name: "Admin"}},
+			},
+		},
+		{
+			// Multiple entries covering all three environments.
+			name:   "multiple entries dev/test/prod via native list",
+			inName: "Full Access",
+			email:  "full@example.com",
+			profile: map[string]interface{}{
+				"env_roles": []interface{}{"dev:Admin", "test:Operator", "prod:Analyst"},
+			},
+			expected: client.InviteCollaboratorRequest{
+				Name:  "Full Access",
+				Email: "full@example.com",
 				EnvRoles: []client.InviteEnvRole{
 					{EnvironmentType: "dev", Name: "Admin"},
 					{EnvironmentType: "test", Name: "Operator"},
@@ -133,21 +157,52 @@ func TestBuildInviteRequest(t *testing.T) {
 			},
 		},
 		{
-			name:    "subset — only prod_role; empty roles skipped",
-			inName:  "Prod Only",
-			email:   "prod@example.com",
-			profile: map[string]interface{}{"dev_role": "", "prod_role": "Analyst"},
+			// Blank entry in the list is silently skipped.
+			name:   "blank entry skipped",
+			inName: "Blank Test",
+			email:  "blank@example.com",
+			profile: map[string]interface{}{
+				"env_roles": []interface{}{"", "dev:Admin"},
+			},
 			expected: client.InviteCollaboratorRequest{
-				Name:     "Prod Only",
-				Email:    "prod@example.com",
-				EnvRoles: []client.InviteEnvRole{{EnvironmentType: "prod", Name: "Analyst"}},
+				Name:     "Blank Test",
+				Email:    "blank@example.com",
+				EnvRoles: []client.InviteEnvRole{{EnvironmentType: "dev", Name: "Admin"}},
 			},
 		},
 		{
-			name:    "roles + user_group_ids together",
-			inName:  "Grouped",
-			email:   "grouped@example.com",
-			profile: map[string]interface{}{"dev_role": "Admin", "user_group_ids": " 10 , 20 "},
+			// Entry with no colon is silently skipped.
+			name:   "malformed entry (no colon) skipped",
+			inName: "Malformed Test",
+			email:  "malformed@example.com",
+			profile: map[string]interface{}{
+				"env_roles": []interface{}{"AdminNoColon", "dev:Admin"},
+			},
+			expected: client.InviteCollaboratorRequest{
+				Name:     "Malformed Test",
+				Email:    "malformed@example.com",
+				EnvRoles: []client.InviteEnvRole{{EnvironmentType: "dev", Name: "Admin"}},
+			},
+		},
+		{
+			// Unknown env prefix is silently skipped.
+			name:   "unknown env prefix skipped",
+			inName: "Unknown Env",
+			email:  "unknown@example.com",
+			profile: map[string]interface{}{
+				"env_roles": []interface{}{"staging:Admin"},
+			},
+			expected: client.InviteCollaboratorRequest{Name: "Unknown Env", Email: "unknown@example.com"},
+		},
+		{
+			// env_roles list + user_group_ids string together.
+			name:   "env_roles + user_group_ids",
+			inName: "Grouped",
+			email:  "grouped@example.com",
+			profile: map[string]interface{}{
+				"env_roles":     []interface{}{"dev:Admin"},
+				"user_group_ids": " 10 , 20 ",
+			},
 			expected: client.InviteCollaboratorRequest{
 				Name:         "Grouped",
 				Email:        "grouped@example.com",

--- a/pkg/connector/collaborator_test.go
+++ b/pkg/connector/collaborator_test.go
@@ -124,11 +124,12 @@ func TestOptionalStringListField(t *testing.T) {
 
 func TestBuildInviteRequest(t *testing.T) {
 	tests := []struct {
-		name     string
-		inName   string
-		email    string
-		profile  map[string]interface{}
-		expected client.InviteCollaboratorRequest
+		name              string
+		inName            string
+		email             string
+		profile           map[string]interface{}
+		expected          client.InviteCollaboratorRequest
+		expectedMalformed []string
 	}{
 		{
 			name:     "minimal — no env_roles field",
@@ -184,8 +185,8 @@ func TestBuildInviteRequest(t *testing.T) {
 			},
 		},
 		{
-			// Entry with no colon is silently skipped.
-			name:   "malformed entry (no colon) skipped",
+			// Entry with no colon is reported as malformed, valid entries still parsed.
+			name:   "malformed entry (no colon) reported",
 			inName: "Malformed Test",
 			email:  "malformed@example.com",
 			profile: map[string]interface{}{
@@ -196,16 +197,18 @@ func TestBuildInviteRequest(t *testing.T) {
 				Email:    "malformed@example.com",
 				EnvRoles: []client.InviteEnvRole{{EnvironmentType: "dev", Name: "Admin"}},
 			},
+			expectedMalformed: []string{"AdminNoColon"},
 		},
 		{
-			// Unknown env prefix is silently skipped.
-			name:   "unknown env prefix skipped",
+			// Unknown env prefix is reported as malformed.
+			name:   "unknown env prefix reported",
 			inName: "Unknown Env",
 			email:  "unknown@example.com",
 			profile: map[string]interface{}{
 				"env_roles": []interface{}{"staging:Admin"},
 			},
-			expected: client.InviteCollaboratorRequest{Name: "Unknown Env", Email: "unknown@example.com"},
+			expected:          client.InviteCollaboratorRequest{Name: "Unknown Env", Email: "unknown@example.com"},
+			expectedMalformed: []string{"staging:Admin"},
 		},
 		{
 			// env_roles list + user_group_ids string together.
@@ -226,9 +229,12 @@ func TestBuildInviteRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildInviteRequest(tt.inName, tt.email, tt.profile)
+			got, malformed := buildInviteRequest(tt.inName, tt.email, tt.profile)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("buildInviteRequest() = %#v, want %#v", got, tt.expected)
+			}
+			if !reflect.DeepEqual(malformed, tt.expectedMalformed) {
+				t.Errorf("buildInviteRequest() malformed = %#v, want %#v", malformed, tt.expectedMalformed)
 			}
 		})
 	}

--- a/pkg/connector/collaborator_test.go
+++ b/pkg/connector/collaborator_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-workato/pkg/connector/client"
 )
@@ -16,11 +17,11 @@ import (
 // verbatim to Workato's invite API, which rejects it with "400 Email is invalid".
 func TestResolveInviteEmail(t *testing.T) {
 	tests := []struct {
-		name           string
-		login          string
-		emailAddresses []string
-		profileMap     map[string]interface{}
-		want           string
+		name       string
+		login      string
+		emails     []*v2.AccountInfo_Email
+		profileMap map[string]interface{}
+		want       string
 	}{
 		{
 			// Repro: C1 login is a handle (not an email). Mapped profile email must win.
@@ -45,11 +46,23 @@ func TestResolveInviteEmail(t *testing.T) {
 		},
 		{
 			// Handle login, no mapped email, but GetEmails populated → use first address.
-			name:           "handle login + GetEmails fallback",
-			login:          "handle",
-			profileMap:     map[string]interface{}{},
-			emailAddresses: []string{"handle@company.com"},
-			want:           "handle@company.com",
+			name:       "handle login + GetEmails fallback",
+			login:      "handle",
+			profileMap: map[string]interface{}{},
+			emails:     []*v2.AccountInfo_Email{{Address: "handle@company.com"}},
+			want:       "handle@company.com",
+		},
+		{
+			// Multiple emails where primary is not first — primary must be chosen.
+			name:       "multiple emails, primary not first -> primary chosen",
+			login:      "handle",
+			profileMap: map[string]interface{}{},
+			emails: []*v2.AccountInfo_Email{
+				{Address: "first@example.com", IsPrimary: false},
+				{Address: "primary@example.com", IsPrimary: true},
+				{Address: "second@example.com", IsPrimary: false},
+			},
+			want: "primary@example.com",
 		},
 		{
 			// Nothing available → empty string; caller returns an error.
@@ -69,7 +82,7 @@ func TestResolveInviteEmail(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveInviteEmail(tt.login, tt.emailAddresses, tt.profileMap)
+			got := resolveInviteEmail(tt.login, tt.emails, tt.profileMap)
 			if got != tt.want {
 				t.Errorf("resolveInviteEmail() = %q, want %q", got, tt.want)
 			}

--- a/pkg/connector/collaborator_test.go
+++ b/pkg/connector/collaborator_test.go
@@ -10,6 +10,73 @@ import (
 	"github.com/conductorone/baton-workato/pkg/connector/client"
 )
 
+// TestResolveInviteEmail is the repro test for CXH-1958.
+// Before the fix, GetLogin() was used first and profileMap["email"] was only a
+// fallback for an empty login — so a handle login (non-email) would be sent
+// verbatim to Workato's invite API, which rejects it with "400 Email is invalid".
+func TestResolveInviteEmail(t *testing.T) {
+	tests := []struct {
+		name           string
+		login          string
+		emailAddresses []string
+		profileMap     map[string]interface{}
+		want           string
+	}{
+		{
+			// Repro: C1 login is a handle (not an email). Mapped profile email must win.
+			name:       "handle login + mapped email → mapped email wins",
+			login:      "carolinaroncaglia",
+			profileMap: map[string]interface{}{"email": "carolina@example.com"},
+			want:       "carolina@example.com",
+		},
+		{
+			// Mapped email preferred even when login is email-shaped.
+			name:       "mapped email preferred over email-shaped login",
+			login:      "user@example.com",
+			profileMap: map[string]interface{}{"email": "mapped@example.com"},
+			want:       "mapped@example.com",
+		},
+		{
+			// Login is email-shaped and no profile email present → use login.
+			name:       "email-shaped login, no mapped email → login used",
+			login:      "user@example.com",
+			profileMap: map[string]interface{}{},
+			want:       "user@example.com",
+		},
+		{
+			// Handle login, no mapped email, but GetEmails populated → use first address.
+			name:           "handle login + GetEmails fallback",
+			login:          "handle",
+			profileMap:     map[string]interface{}{},
+			emailAddresses: []string{"handle@company.com"},
+			want:           "handle@company.com",
+		},
+		{
+			// Nothing available → empty string; caller returns an error.
+			name:       "all sources empty → empty string",
+			login:      "",
+			profileMap: map[string]interface{}{},
+			want:       "",
+		},
+		{
+			// Whitespace-only login is not email-shaped.
+			name:       "whitespace-only login + no mapped email → empty",
+			login:      "   ",
+			profileMap: map[string]interface{}{},
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveInviteEmail(tt.login, tt.emailAddresses, tt.profileMap)
+			if got != tt.want {
+				t.Errorf("resolveInviteEmail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOptionalStringListField(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -71,35 +71,17 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 					Placeholder: "Jane Doe",
 					Order:       2,
 				},
-				"dev_role": {
-					DisplayName: "Development Role",
-					Required:    false,
-					Description: "Workato role NAME for the Development environment — privilege-group (e.g. \"Admin\") or environment role; type detected automatically.",
-					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
-						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
+				"env_roles": {
+					DisplayName: "Environment Roles",
+					Required:    true,
+					Description: "List of environment + role assignments in \"env:role\" format " +
+						"(e.g. \"dev:Admin\", \"prod:Analyst\"). Allowed environments: dev, test, prod. " +
+						"At least one entry is required. The role must exist in the target environment — " +
+						"a non-provisioned environment fails at invite time with \"Environment <env> not found\".",
+					Field: &v2.ConnectorAccountCreationSchema_Field_StringListField{
+						StringListField: &v2.ConnectorAccountCreationSchema_StringListField{},
 					},
-					Placeholder: "Admin",
-					Order:       3,
-				},
-				"test_role": {
-					DisplayName: "Test Role",
-					Required:    false,
-					Description: "Workato role NAME for the Test environment — privilege-group (e.g. \"Operator\") or environment role; type detected automatically.",
-					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
-						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
-					},
-					Placeholder: "Operator",
-					Order:       4,
-				},
-				"prod_role": {
-					DisplayName: "Production Role",
-					Required:    false,
-					Description: "Workato role NAME for the Production environment — privilege-group (e.g. \"Analyst\") or environment role; type detected automatically.",
-					Field: &v2.ConnectorAccountCreationSchema_Field_StringField{
-						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
-					},
-					Placeholder: "Analyst",
-					Order:       5,
+					Order: 3,
 				},
 				"user_group_ids": {
 					DisplayName: "User Group IDs",
@@ -109,7 +91,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 						StringField: &v2.ConnectorAccountCreationSchema_StringField{},
 					},
 					Placeholder: "am-WxEKCibh-dTXBtz,am-AbCdEfGh-iJkLmNo",
-					Order:       6,
+					Order:       4,
 				},
 			},
 		},


### PR DESCRIPTION
## CXH-1957 — Required `env_roles` StringListField (also in this PR)

> **INTENT (CXH-1957):** The three optional per-environment role fields (`dev_role`,
> `test_role`, `prod_role`) let an operator submit a provisioning request with **no**
> environment role at all, which Workato rejects at invite time with a 400
> (`role_name or env_roles is required`). Collapse them into a single **required** list
> field so C1 forces at least one entry before the request is submitted, and document
> the expected format.

Collapses `dev_role` / `test_role` / `prod_role` into one **required** `env_roles`
`StringListField` (same shape baton-lucidchart ships for `Roles`). Each entry is
`env:role` (e.g. `dev:Admin`); allowed envs `dev`/`test`/`prod`. `Required: true` makes
C1 enforce ≥1 entry in the mapping UI, and a runtime guard rejects an empty list with a
clear message. `user_group_ids` is unchanged (now Order 4).

Updated in the same commit: `.github/workflows/ci.yaml` account-profile fixture, the
in-process test-server expectations, and `docs/connector.mdx` (new *Provision accounts*
section documenting the `env:role` format and the `Environment not found` caveat).

`Fixes CXH-1957`

---

## INTENT (acceptance criteria)

> `baton-workato` account provisioning (`CreateAccount`, collaborator invite) uses the C1 identity
> login as the email it sends to Workato's `POST /api/member_invitations`. In the C1 UI provisioning
> flow, `accountInfo.GetLogin()` is C1's internal identity login — the user's `Username` field in C1
> (a handle), not the user's email — so the connector sends a non-email value and Workato rejects the
> invite with `400 Bad Request: Email is invalid`. The mapped `email` profile field is ignored because
> the connector only falls back to it when the login is empty; it never validates that the login is
> email-shaped and never consults `accountInfo.GetEmails()`.
>
> The fix has to make CreateAccount use the mapped email (or `GetEmails()`, or validate that the login
> is email-shaped).

Fixes CXH-1958

## What

Before this fix, `CreateAccount` resolved the Workato invite email with:

```go
email := accountInfo.GetLogin()
if email == "" {
    email, _ = profileMap["email"].(string)
}
```

`GetLogin()` won whenever non-empty. Since C1's login is the user's **Username** field (a handle like `carolinaroncaglia`, not an email), Workato rejected the invite with `400 Email is invalid`.

## Why

The mapped `profile["email"]` field is C1's canonical email for the identity — it is populated from the directory user's real email address. The login/username is not guaranteed to be email-shaped. The old fallback order was backwards.

## How

Extract `resolveInviteEmail()` that resolves the best email address in priority order:

1. **`profileMap["email"]`** — the C1-mapped profile email field (highest trust, most reliable)
2. **`accountInfo.GetLogin()`** — but only when `isEmailShaped()` validates it contains a proper `@` with non-empty local and domain parts
3. **`accountInfo.GetEmails()`** — first non-empty address as last resort

This matches the precedent in `baton-crowdstrike` (profile email preferred, login only when `validateEmail` passes) and `baton-coupa` (also consults `GetEmails()`).

## How Tested

- **Unit tests** (`go test ./...` — green): Added `TestResolveInviteEmail` with 6 cases including the direct repro (`login="carolinaroncaglia"` + `profile["email"]="carolina@example.com"` → `"carolina@example.com"`). This test would have failed against the old code.
- **Build**: `go build ./...` — green.
- **verify-implementation**: Skipped — the `.env` in the repo has a sandbox Workato API key (`BATON_WORKATO_DATA_CENTER=sandbox`) but the `PROVISIONING_COLLABORATOR_LOGIN` is already email-formatted (`sergio.corral+wktest7@conductorone.com`), so it would not exercise the repro path. The fix is fully covered by unit tests as is conventional for this connector.
- **Connector review**: Code review via `/code-review` — 0 critical findings. Two PLAUSIBLE low-severity notes (IsPrimary not preferred in GetEmails fallback; isEmailShaped with LastIndex theoretically accepts double-@ logins) and one confirmed cleanup (redundant TrimSpace around optionalStringField). None block this fix.

## ⚠️ Breaking change — account-provisioning schema

CXH-1957 replaces the three optional account-creation fields `dev_role` / `test_role` / `prod_role` with a single **required** `env_roles` `StringListField`. Any existing C1 account-provisioning policy or attribute mapping that populated the old fields stops taking effect: the old fields no longer exist, so `env_roles` arrives empty and the invite is rejected by the `InvalidArgument "at least one environment role is required"` guard.

**Migration:** remap account provisioning to the new `env_roles` list — one `env:role` entry per environment (e.g. `dev:Admin`, `prod:Analyst`; envs `dev`/`test`/`prod`). There is no automatic migration. Account provisioning on this connector is new as of CXH-1494, so no long-standing production mappings are expected to break. Documented in `docs/connector.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

