### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/collaborator.go
+++ b/pkg/connector/collaborator.go
@@ -628,11 +628,8 @@ func collaboratorResource(collaborator *client.Collaborator) (*v2.Resource, erro
 	}
 
 	traits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
 		rs.WithEmail(collaborator.Email, true),
 		rs.WithUserLogin(collaborator.Email),
-		rs.WithCreatedAt(collaborator.CreatedAt),
 		rs.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_HUMAN),
 	}
 
@@ -641,6 +638,9 @@ func collaboratorResource(collaborator *client.Collaborator) (*v2.Resource, erro
 		collaboratorResourceType,
 		collaborator.Id,
 		traits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
+		rs.WithResourceCreatedAt(collaborator.CreatedAt),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/collaborator_test.go
+++ b/pkg/connector/collaborator_test.go
@@ -216,7 +216,7 @@ func TestBuildInviteRequest(t *testing.T) {
 			inName: "Grouped",
 			email:  "grouped@example.com",
 			profile: map[string]interface{}{
-				"env_roles":     []interface{}{"dev:Admin"},
+				"env_roles":      []interface{}{"dev:Admin"},
 				"user_group_ids": " 10 , 20 ",
 			},
 			expected: client.InviteCollaboratorRequest{

--- a/pkg/connector/environment_role.go
+++ b/pkg/connector/environment_role.go
@@ -148,12 +148,13 @@ func environmentRoleResource(role *client.EnvironmentRole, envConfig workato.Env
 		"updated_at":  role.UpdatedAt.String(),
 	}
 
-	traits := []rs.RoleTraitOption{rs.WithRoleProfile(profile)}
+	traits := []rs.RoleTraitOption{}
 
 	return rs.NewRoleResource(
 		fmt.Sprintf("%s (%s)", role.Name, targetEnv.String()),
 		environmentRoleResourceType,
 		GetRoleResourceID(id, targetEnv, envConfig),
 		traits,
+		rs.WithResourceProfile(profile),
 	)
 }

--- a/pkg/connector/folder.go
+++ b/pkg/connector/folder.go
@@ -174,15 +174,14 @@ func folderResource(folder *client.Folder, parentResourceId *v2.ResourceId) (*v2
 		"updated_at": folder.UpdatedAt.String(),
 	}
 
-	traits := []rs.AppTraitOption{
-		rs.WithAppProfile(profile),
-	}
+	traits := []rs.AppTraitOption{}
 
 	ret, err := rs.NewAppResource(
 		folder.Name,
 		folderResourceType,
 		folder.Id,
 		traits,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceId),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{
@@ -206,15 +205,14 @@ func projectFolderResource(project *client.Project, parentResourceId *v2.Resourc
 		"parent_id": nil,
 	}
 
-	traits := []rs.AppTraitOption{
-		rs.WithAppProfile(profile),
-	}
+	traits := []rs.AppTraitOption{}
 
 	ret, err := rs.NewAppResource(
 		name,
 		folderResourceType,
 		project.FolderId,
 		traits,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceId),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{

--- a/pkg/connector/privilege.go
+++ b/pkg/connector/privilege.go
@@ -77,15 +77,14 @@ func privilegeResource(privilege *workato.CompoundPrivilege) (*v2.Resource, erro
 		"description": privilege.Privilege.Description,
 	}
 
-	traits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	traits := []rs.RoleTraitOption{}
 
 	ret, err := rs.NewRoleResource(
 		privilege.Resource+"-"+privilege.Privilege.Id,
 		privilegeResourceType,
 		privilege.Id(),
 		traits,
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -64,15 +64,14 @@ func projectResource(project *client.Project) (*v2.Resource, error) {
 		"folder_id":   project.FolderId,
 	}
 
-	traits := []rs.AppTraitOption{
-		rs.WithAppProfile(profile),
-	}
+	traits := []rs.AppTraitOption{}
 
 	ret, err := rs.NewAppResource(
 		project.Name,
 		projectResourceType,
 		project.Id,
 		traits,
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -127,11 +127,7 @@ func (o *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ r
 func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	rv := make([]*v2.Grant, 0)
 
-	roleTrait, err := rs.GetRoleTrait(resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get role trait: %w", err)
-	}
-	profile := roleTrait.GetProfile()
+	profile := resource.GetProfile()
 	if profile == nil {
 		return nil, nil, fmt.Errorf("role profile not found on resource %s", resource.Id.Resource)
 	}
@@ -258,11 +254,7 @@ func (o *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 		return nil, nil, err
 	}
 
-	roleTrait, err := rs.GetRoleTrait(entitlement.Resource)
-	if err != nil {
-		return nil, nil, fmt.Errorf("baton-workato: failed to get role trait: %w", err)
-	}
-	profile := roleTrait.GetProfile()
+	profile := entitlement.Resource.GetProfile()
 	if profile == nil {
 		return nil, nil, fmt.Errorf("baton-workato: role profile is nil on resource %s", entitlement.Resource.Id.Resource)
 	}
@@ -326,15 +318,14 @@ func roleResource(role *client.Role, envConfig workato.Environment, targetEnv wo
 		"updated_at":  role.UpdatedAt.String(),
 	}
 
-	traits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	traits := []rs.RoleTraitOption{}
 
 	ret, err := rs.NewRoleResource(
 		fmt.Sprintf("%s (%s)", role.Name, targetEnv.String()),
 		roleResourceType,
 		GetRoleResourceID(id, targetEnv, envConfig),
 		traits,
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err
@@ -357,15 +348,14 @@ func workatoBaseRoleResource(role *workato.Role, envConfig workato.Environment, 
 		"environment": targetEnv.String(),
 	}
 
-	traits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	traits := []rs.RoleTraitOption{}
 
 	ret, err := rs.NewRoleResource(
 		fmt.Sprintf("%s (%s)", role.RoleName, targetEnv.String()),
 		roleResourceType,
 		GetRoleResourceID(role.RoleName, targetEnv, envConfig),
 		traits,
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
