### PR TITLE
Use baton-sdk resource attribute helpers for profile/status reads

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -127,7 +127,7 @@ func (o *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ r
 func (o *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, attr rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	rv := make([]*v2.Grant, 0)
 
-	profile := resource.GetProfile()
+	profile := rs.GetProfile(resource)
 	if profile == nil {
 		return nil, nil, fmt.Errorf("role profile not found on resource %s", resource.Id.Resource)
 	}
@@ -254,7 +254,7 @@ func (o *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 		return nil, nil, err
 	}
 
-	profile := entitlement.Resource.GetProfile()
+	profile := rs.GetProfile(entitlement.Resource)
 	if profile == nil {
 		return nil, nil, fmt.Errorf("baton-workato: role profile is nil on resource %s", entitlement.Resource.Id.Resource)
 	}


### PR DESCRIPTION
Follow-up to the trait profile/status migration.

That migration moved reads from the deprecated trait fields to the resource
itself (`r.GetProfile()`). That is correct for data written by a connector which
has already migrated, but it returns nothing for data synced **before** the
migration, where the profile still lives on the trait annotation.

baton-sdk provides compatibility getters for exactly this
(`pkg/types/resource/resource_attrs.go`): `GetProfile`, `GetStatus`,
`GetCreatedAt`, and `GetIcon` read the resource-level attribute first and fall
back to the deprecated trait field. This switches the reads to those helpers so
previously-synced data still resolves.

Reads only — the write side (`WithResourceProfile` / `WithResourceStatus`) is
unchanged. Reference: ConductorOne/baton-sql#143.

`golangci-lint run ./...` reports 0 issues and the package tests pass.
